### PR TITLE
Removed `shared_ptr` from the GHA and AHA

### DIFF
--- a/clove/components/core/audio/include/Clove/Audio/AhaSource.hpp
+++ b/clove/components/core/audio/include/Clove/Audio/AhaSource.hpp
@@ -20,14 +20,14 @@ namespace clove {
         /**
 		 * @brief Sets buffer to play audio from
 		 */
-        virtual void setBuffer(std::shared_ptr<AhaBuffer> buffer) = 0;
+        virtual void setBuffer(std::unique_ptr<AhaBuffer> buffer) = 0;
 
         /**
 		 * @brief Queues buffers to be played sequentially.
 		 * @details Buffers are appended to the end of the current queue.
 		 * @param buffers Vector of buffers to add to the queue.
 		 */
-        virtual void queueBuffers(std::vector<std::shared_ptr<AhaBuffer>> buffers) = 0;
+        virtual void queueBuffers(std::vector<std::unique_ptr<AhaBuffer>> buffers) = 0;
         /**
 		 * @brief Removes processed buffers from the queue.
 		 * @details Processed buffers can be removed from the queue, allowing their data 
@@ -36,7 +36,7 @@ namespace clove {
 		 * @param numToQueue The number of buffers to remove from the queue. must be <= getNumBuffersProcessed.
 		 * @returns A vector of AudioBuffers removed from the queue.
 		 */
-        virtual std::vector<std::shared_ptr<AhaBuffer>> unQueueBuffers(uint32_t const numToUnqueue) = 0;
+        virtual std::vector<std::unique_ptr<AhaBuffer>> unQueueBuffers(uint32_t const numToUnqueue) = 0;
 
         virtual void setPitch(float pitch)      = 0;
         virtual void setLooping(bool isLooping) = 0;

--- a/clove/components/core/audio/include/Clove/Audio/OpenAL/OpenAlSource.hpp
+++ b/clove/components/core/audio/include/Clove/Audio/OpenAL/OpenAlSource.hpp
@@ -10,7 +10,7 @@ namespace clove {
     private:
         ALuint source{};
 
-        std::vector<std::shared_ptr<AhaBuffer>> bufferQueue;
+        std::vector<std::unique_ptr<AhaBuffer>> bufferQueue;
 
         //FUNCTIONS
     public:
@@ -25,10 +25,10 @@ namespace clove {
 
         ~OpenAlSource();
 
-        void setBuffer(std::shared_ptr<AhaBuffer> buffer) override;
+        void setBuffer(std::unique_ptr<AhaBuffer> buffer) override;
 
-        void queueBuffers(std::vector<std::shared_ptr<AhaBuffer>> buffers) override;
-        std::vector<std::shared_ptr<AhaBuffer>> unQueueBuffers(uint32_t const numToUnqueue) override;
+        void queueBuffers(std::vector<std::unique_ptr<AhaBuffer>> buffers) override;
+        std::vector<std::unique_ptr<AhaBuffer>> unQueueBuffers(uint32_t const numToUnqueue) override;
 
         void setPitch(float pitch) override;
         void setLooping(bool isLooping) override;

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -31,7 +31,7 @@ namespace clove {
 
         alCall(alSourcei(source, AL_BUFFER, alBuffer->getBufferId()));
 
-        bufferQueue.empty();
+        bufferQueue.clear();
         bufferQueue.push_back( std::move(buffer) );
     }
 

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -80,11 +80,7 @@ namespace clove {
 
             ALuint const bufferId{ alBuffer->getBufferId() };
 
-            if(pendingBuffers.find(bufferId) != pendingBuffers.end()) {
-                return true;
-            }
-
-            return false;
+            return pendingBuffers.find(bufferId) != pendingBuffers.end();
         });
 
         std::vector<std::unique_ptr<AhaBuffer>> removedBuffers{};

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -21,20 +21,21 @@ namespace clove {
         alCall(alDeleteSources(1, &source));
     }
 
-    void OpenAlSource::setBuffer(std::shared_ptr<AhaBuffer> buffer) {
+    void OpenAlSource::setBuffer(std::unique_ptr<AhaBuffer> buffer) {
         OpenAlBuffer const *const alBuffer{ polyCast<OpenAlBuffer const>(buffer.get()) };
-        
-        if(alBuffer == nullptr){
+
+        if(alBuffer == nullptr) {
             CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0} called with nullptr", CLOVE_FUNCTION_NAME_PRETTY);
             return;
         }
 
         alCall(alSourcei(source, AL_BUFFER, alBuffer->getBufferId()));
 
-        bufferQueue = { buffer };
+        bufferQueue.empty();
+        bufferQueue.push_back( std::move(buffer) );
     }
 
-    void OpenAlSource::queueBuffers(std::vector<std::shared_ptr<AhaBuffer>> buffers) {
+    void OpenAlSource::queueBuffers(std::vector<std::unique_ptr<AhaBuffer>> buffers) {
         //Get the buffer Id of all of the buffers to placed into the queue
         std::vector<ALuint> alBuffers(buffers.size());
         for(size_t i{ 0 }; i < std::size(alBuffers); ++i) {
@@ -46,12 +47,14 @@ namespace clove {
             }
         }
 
-        alCall(alSourceQueueBuffers(source, std::size(alBuffers), alBuffers.data()));
+        alCall(alSourceQueueBuffers(source, alBuffers.size(), alBuffers.data()));
 
-        bufferQueue.insert(bufferQueue.end(), buffers.begin(), buffers.end());
+        for(auto &buffer : buffers) {
+            bufferQueue.push_back(std::move(buffer));
+        }
     }
 
-    std::vector<std::shared_ptr<AhaBuffer>> OpenAlSource::unQueueBuffers(uint32_t const numToUnqueue) {
+    std::vector<std::unique_ptr<AhaBuffer>> OpenAlSource::unQueueBuffers(uint32_t const numToUnqueue) {
 #if CLOVE_DEBUG
         const uint32_t maxAbleToUnQueue{ getNumBuffersProcessed() };
         CLOVE_ASSERT(numToUnqueue <= maxAbleToUnQueue, "{0}, Can't unqueue {1} buffers. Only {2} buffers have been processed", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
@@ -67,10 +70,7 @@ namespace clove {
 
         delete[] buffers;
 
-        std::vector<std::shared_ptr<AhaBuffer>> removedBuffers;
-        removedBuffers.reserve(numToUnqueue);
-
-        auto removeIter = std::remove_if(bufferQueue.begin(), bufferQueue.end(), [&](std::shared_ptr<AhaBuffer> const &buffer) {
+        auto removeIter = std::remove_if(bufferQueue.begin(), bufferQueue.end(), [&](std::unique_ptr<AhaBuffer> const &buffer) {
             OpenAlBuffer const *const alBuffer{ polyCast<OpenAlBuffer const>(buffer.get()) };
 
             if(alBuffer == nullptr) {
@@ -81,12 +81,16 @@ namespace clove {
             ALuint const bufferId{ alBuffer->getBufferId() };
 
             if(pendingBuffers.find(bufferId) != pendingBuffers.end()) {
-                removedBuffers.push_back(buffer);
                 return true;
             }
 
             return false;
         });
+
+        std::vector<std::unique_ptr<AhaBuffer>> removedBuffers{};
+        for(auto iter{ removeIter }; iter != bufferQueue.end(); ++iter) {
+            removedBuffers.push_back(std::move(*iter));
+        }
 
         bufferQueue.erase(removeIter, bufferQueue.end());
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputePipelineObject.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputePipelineObject.hpp
@@ -2,7 +2,6 @@
 
 #include "Clove/Graphics/PipelineObject.hpp"
 
-#include <memory>
 #include <vector>
 
 namespace clove {
@@ -15,9 +14,9 @@ namespace clove {
         //TYPES
     public:
         struct Descriptor {
-            std::shared_ptr<GhaShader> shader;
+            GhaShader const *shader{ nullptr };
 
-            std::vector<std::shared_ptr<GhaDescriptorSetLayout>> descriptorSetLayouts;
+            std::vector<GhaDescriptorSetLayout const *> descriptorSetLayouts;
             std::vector<PushConstantDescriptor> pushConstants;
         };
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
@@ -3,14 +3,17 @@
 #include "Clove/Graphics/GhaComputeCommandBuffer.hpp"
 #include "Clove/Graphics/GhaGraphicsPipelineObject.hpp"
 
+#include <memory>
+#include <vector>
+
 namespace clove {
     class GhaFence;
     class GhaSemaphore;
 
     struct ComputeSubmitInfo {
-        std::vector<std::pair<std::shared_ptr<GhaSemaphore>, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
-        std::vector<std::shared_ptr<GhaComputeCommandBuffer>> commandBuffers;                /**< The command buffers to execute */
-        std::vector<std::shared_ptr<GhaSemaphore>> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
+        std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
+        std::vector<GhaComputeCommandBuffer const *> commandBuffers;                /**< The command buffers to execute */
+        std::vector<GhaSemaphore const *> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
     };
 }
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
@@ -12,7 +12,7 @@ namespace clove {
 
     struct ComputeSubmitInfo {
         std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
-        std::vector<GhaComputeCommandBuffer const *> commandBuffers;                /**< The command buffers to execute */
+        std::vector<GhaComputeCommandBuffer *> commandBuffers;                      /**< The command buffers to execute */
         std::vector<GhaSemaphore const *> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDescriptorPool.hpp
@@ -46,17 +46,17 @@ namespace clove {
         /** 
          * @brief Allocates a descriptor set for each layout provided.
          */
-        virtual std::shared_ptr<GhaDescriptorSet> allocateDescriptorSets(std::shared_ptr<GhaDescriptorSetLayout> const &layout)                            = 0;
-        virtual std::vector<std::shared_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSetLayout>> const &layouts) = 0;
+        virtual std::unique_ptr<GhaDescriptorSet> allocateDescriptorSets(GhaDescriptorSetLayout const *const layout)                              = 0;
+        virtual std::vector<std::unique_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<GhaDescriptorSetLayout const *> const &layouts) = 0;
 
         /**
          * @brief Free an individual descriptor set. Requires Flag::FreeDescriptorSet to be set on creation.
          */
-        virtual void freeDescriptorSets(std::shared_ptr<GhaDescriptorSet> const &descriptorSet) = 0;
+        virtual void freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) = 0;
         /**
          * @brief Frees individual descriptor sets. Requires Flag::FreeDescriptorSet to be set on creation.
          */
-        virtual void freeDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSet>> const &descriptorSets) = 0;
+        virtual void freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) = 0;
 
         /**
          * @brief Resets this pool freeing all DescriptorSets allocated from it.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <memory>
-
-namespace clove{
+namespace clove {
     class GhaFactory;
 }
 
@@ -13,7 +11,7 @@ namespace clove {
     class GhaDevice {
         //TYPES
     public:
-        struct Limits{
+        struct Limits {
             size_t minUniformBufferOffsetAlignment{ 0 };
         };
 
@@ -21,7 +19,12 @@ namespace clove {
     public:
         virtual ~GhaDevice() = default;
 
-        virtual std::shared_ptr<GhaFactory> getGraphicsFactory() const = 0;
+        /**
+         * @brief Returns a pointer to the factory object. The lifetime of the 
+         * factory is tied to the lifetime of this device.
+         * @return 
+         */
+        virtual GhaFactory *getGraphicsFactory() const = 0;
 
         /**
          * @brief Stalls the current thread until the device is idle.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace clove {
     class GhaFactory;
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaFramebuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaFramebuffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 
 namespace clove {
@@ -16,8 +15,8 @@ namespace clove {
         //TYPES
     public:
         struct Descriptor {
-            std::shared_ptr<GhaRenderPass> renderPass;
-            std::vector<std::shared_ptr<GhaImageView>> attachments; /**< The order of the attachments here has to match the those in the corresponding render pass. ColourAttachments + DepthStencilAttachment. */
+            GhaRenderPass const *renderPass{ nullptr };
+            std::vector<GhaImageView const *> attachments; /**< The order of the attachments here has to match the those in the corresponding render pass. ColourAttachments + DepthStencilAttachment. */
             uint32_t width{ 0 };
             uint32_t height{ 0 };
         };

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaFramebuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaFramebuffer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <cinttypes>
 
 namespace clove {
     class GhaRenderPass;

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsCommandBuffer.hpp
@@ -96,7 +96,7 @@ namespace clove {
          * @param size The size of the push constant range to update.
          * @param data The data to upload.
          */
-        virtual void pushConstant(GhaShader::Stage const stage, size_t const offset, size_t const size, void const *data) = 0;
+        virtual void pushConstant(GhaShader::Stage const stage, size_t const offset, size_t const size, void const *const data) = 0;
 
         virtual void drawIndexed(size_t const indexCount) = 0;
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsPipelineObject.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsPipelineObject.hpp
@@ -4,7 +4,6 @@
 #include "Clove/Graphics/PipelineObject.hpp"
 
 #include <Clove/Maths/Vector.hpp>
-#include <memory>
 #include <vector>
 
 namespace clove {
@@ -58,8 +57,8 @@ namespace clove {
         //TYPES
     public:
         struct Descriptor {
-            std::shared_ptr<GhaShader> vertexShader;
-            std::shared_ptr<GhaShader> pixelShader;
+            GhaShader const *vertexShader{ nullptr };
+            GhaShader const *pixelShader{ nullptr };
 
             VertexInputBindingDescriptor vertexInput;
             std::vector<VertexAttributeDescriptor> vertexAttributes; /**< The index of each element maps to the layout(location = x) in the vertex shader. */
@@ -73,9 +72,9 @@ namespace clove {
 
             bool enableBlending{ true };
 
-            std::shared_ptr<GhaRenderPass> renderPass;
+            GhaRenderPass const *renderPass{ nullptr };
 
-            std::vector<std::shared_ptr<GhaDescriptorSetLayout>> descriptorSetLayouts;
+            std::vector<GhaDescriptorSetLayout const *> descriptorSetLayouts;
             std::vector<PushConstantDescriptor> pushConstants;
         };
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
@@ -3,14 +3,17 @@
 #include "Clove/Graphics/GhaGraphicsCommandBuffer.hpp"
 #include "Clove/Graphics/GhaGraphicsPipelineObject.hpp"
 
+#include <memory>
+#include <vector>
+
 namespace clove {
     class GhaFence;
     class GhaSemaphore;
 
     struct GraphicsSubmitInfo {
-        std::vector<std::pair<std::shared_ptr<GhaSemaphore>, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
-        std::vector<std::shared_ptr<GhaGraphicsCommandBuffer>> commandBuffers;               /**< The command buffers to execute */
-        std::vector<std::shared_ptr<GhaSemaphore>> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
+        std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
+        std::vector<GhaGraphicsCommandBuffer const *> commandBuffers;             /**< The command buffers to execute */
+        std::vector<GhaSemaphore const *> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
     };
 }
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
@@ -12,7 +12,7 @@ namespace clove {
 
     struct GraphicsSubmitInfo {
         std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
-        std::vector<GhaGraphicsCommandBuffer const *> commandBuffers;             /**< The command buffers to execute */
+        std::vector<GhaGraphicsCommandBuffer *> commandBuffers;             /**< The command buffers to execute */
         std::vector<GhaSemaphore const *> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaPresentQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaPresentQueue.hpp
@@ -11,7 +11,7 @@ namespace clove {
     struct PresentInfo {
         std::vector<GhaSemaphore const *> waitSemaphores;
 
-        GhaSwapchain const *swapChain{ nullptr };
+        GhaSwapchain *swapChain{ nullptr };
         uint32_t imageIndex;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaPresentQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaPresentQueue.hpp
@@ -2,7 +2,6 @@
 
 #include "Clove/Graphics/Result.hpp"
 
-#include <memory>
 #include <vector>
 
 namespace clove {
@@ -10,9 +9,9 @@ namespace clove {
     class GhaSwapchain;
 
     struct PresentInfo {
-        std::vector<std::shared_ptr<GhaSemaphore>> waitSemaphores;
+        std::vector<GhaSemaphore const *> waitSemaphores;
 
-        std::shared_ptr<GhaSwapchain> swapChain;
+        GhaSwapchain const *swapChain{ nullptr };
         uint32_t imageIndex;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaSwapchain.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaSwapchain.hpp
@@ -37,6 +37,11 @@ namespace clove {
         virtual GhaImage::Format getImageFormat() const = 0;
         virtual vec2ui getSize() const                  = 0;
 
-        virtual std::vector<std::shared_ptr<GhaImageView>> getImageViews() const = 0;
+        /**
+         * @brief Return the image views backing this swapchain. The lifetime
+         * of the views are tied to this object.
+         * @return 
+         */
+        virtual std::vector<GhaImageView *> getImageViews() const = 0;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
@@ -10,9 +10,9 @@ namespace clove {
     class GhaSemaphore;
 
     struct TransferSubmitInfo {
-        std::vector<std::pair<std::shared_ptr<GhaSemaphore>, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
-        std::vector<std::shared_ptr<GhaTransferCommandBuffer>> commandBuffers;               /**< The command buffers to execute */
-        std::vector<std::shared_ptr<GhaSemaphore>> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
+        std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores;   /**< What semaphores to wait on at what stage */
+        std::vector<GhaTransferCommandBuffer const *> commandBuffers;                 /**< The command buffers to execute */
+        std::vector<GhaSemaphore const *> signalSemaphores;                           /**< The semaphores that will be signaled when completed */
     };
 }
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
@@ -11,7 +11,7 @@ namespace clove {
 
     struct TransferSubmitInfo {
         std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores;   /**< What semaphores to wait on at what stage */
-        std::vector<GhaTransferCommandBuffer const *> commandBuffers;                 /**< The command buffers to execute */
+        std::vector<GhaTransferCommandBuffer *> commandBuffers;                       /**< The command buffers to execute */
         std::vector<GhaSemaphore const *> signalSemaphores;                           /**< The semaphores that will be signaled when completed */
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorPool.hpp
@@ -56,11 +56,11 @@ namespace clove {
 		
 		Descriptor const &getDescriptor() const override;
 
-		std::shared_ptr<GhaDescriptorSet> allocateDescriptorSets(std::shared_ptr<GhaDescriptorSetLayout> const &layout) override;
-		std::vector<std::shared_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSetLayout>> const &layouts) override;
+		std::unique_ptr<GhaDescriptorSet> allocateDescriptorSets(GhaDescriptorSetLayout const *const layout) override;
+		std::vector<std::unique_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<GhaDescriptorSetLayout const *> const &layouts) override;
 
-		void freeDescriptorSets(std::shared_ptr<GhaDescriptorSet> const &descriptorSet) override;
-		void freeDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSet>> const &descriptorSets) override;
+		void freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) override;
+		void freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) override;
 
 		void reset() override;
 	};

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorSet.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorSet.hpp
@@ -23,12 +23,12 @@ namespace clove {
 		id<MTLBuffer> pixelEncoderBuffer{ nullptr }; /**< The buffer backing the pixel encoder. */
 		id<MTLBuffer> computeEncoderBuffer{ nullptr }; /**< The buffer backing the compute encoder */
 		
-		std::shared_ptr<GhaDescriptorSetLayout> layout{ nullptr };
+		GhaDescriptorSetLayout const *layout{ nullptr };
 		
 		//FUNCTIONS
 	public:
 		MetalDescriptorSet() = delete;
-		MetalDescriptorSet(id<MTLArgumentEncoder> vertexEncoder, id<MTLBuffer> vertexEncoderBuffer, id<MTLArgumentEncoder> pixelEncoder, id<MTLBuffer> pixelEncoderBuffer, id<MTLArgumentEncoder> computeEncoder, id<MTLBuffer> computeEncoderBuffer, std::shared_ptr<GhaDescriptorSetLayout> layout);
+		MetalDescriptorSet(id<MTLArgumentEncoder> vertexEncoder, id<MTLBuffer> vertexEncoderBuffer, id<MTLArgumentEncoder> pixelEncoder, id<MTLBuffer> pixelEncoderBuffer, id<MTLArgumentEncoder> computeEncoder, id<MTLBuffer> computeEncoderBuffer, GhaDescriptorSetLayout const *layout);
 		
 		MetalDescriptorSet(MetalDescriptorSet const &other) = delete;
 		MetalDescriptorSet(MetalDescriptorSet &&other) noexcept;

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDevice.hpp
@@ -18,7 +18,7 @@ namespace clove {
 		//VARIABLES
 	private:
 		std::unique_ptr<DeviceWrapper> wrapper{ nullptr };
-		std::shared_ptr<MetalFactory> factory;
+		std::unique_ptr<MetalFactory> factory;
 		
 		//FUNCTIONS
 	public:
@@ -33,7 +33,7 @@ namespace clove {
 
 		~MetalDevice();
 		
-		std::shared_ptr<GhaFactory> getGraphicsFactory() const override;
+		GhaFactory *getGraphicsFactory() const override;
 
 		void waitForIdleDevice() override;
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalSwapchain.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalSwapchain.hpp
@@ -12,8 +12,8 @@ namespace clove {
 	class MetalSwapchain : public GhaSwapchain {
 		//VARIABLES
 	private:
-		std::vector<std::shared_ptr<GhaImage>> images{};
-		std::vector<std::shared_ptr<GhaImageView>> imageViews{};
+		std::vector<std::unique_ptr<GhaImage>> images{};
+		std::vector<std::unique_ptr<GhaImageView>> imageViews{};
 		
 		GhaImage::Format imageFormat{};
 		vec2ui imageSize{};
@@ -23,7 +23,7 @@ namespace clove {
 		//FUNCTIONS
 	public:
 		MetalSwapchain() = delete;
-		MetalSwapchain(std::vector<std::shared_ptr<GhaImage>> images, GhaImage::Format imageFormat, vec2ui imageSize);
+		MetalSwapchain(std::vector<std::unique_ptr<GhaImage>> images, GhaImage::Format imageFormat, vec2ui imageSize);
 		
 		MetalSwapchain(MetalSwapchain const &other) = delete;
 		MetalSwapchain(MetalSwapchain &&other) noexcept;
@@ -38,7 +38,7 @@ namespace clove {
 		GhaImage::Format getImageFormat() const override;
 		vec2ui getSize() const override;
 
-		std::vector<std::shared_ptr<GhaImageView>> getImageViews() const override;
+		std::vector<GhaImageView *> getImageViews() const override;
 		
 		/**
 		 * @brief Tells the swapchain that the image index is free to use again.

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDescriptorPool.hpp
@@ -4,6 +4,7 @@
 #include "Clove/Graphics/Vulkan/DevicePointer.hpp"
 
 #include <vulkan/vulkan.h>
+#include <vector>
 
 namespace clove {
     class VulkanDescriptorPool : public GhaDescriptorPool {
@@ -29,11 +30,11 @@ namespace clove {
 
         inline Descriptor const &getDescriptor() const override;
 
-        std::shared_ptr<GhaDescriptorSet> allocateDescriptorSets(std::shared_ptr<GhaDescriptorSetLayout> const &layout) override;
-        std::vector<std::shared_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSetLayout>> const &layouts) override;
+        std::unique_ptr<GhaDescriptorSet> allocateDescriptorSets(GhaDescriptorSetLayout const *const layout) override;
+        std::vector<std::unique_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<GhaDescriptorSetLayout const *> const &layouts) override;
 
-        void freeDescriptorSets(std::shared_ptr<GhaDescriptorSet> const &descriptorSet) override;
-        void freeDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSet>> const &descriptorSets) override;
+        void freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) override;
+        void freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) override;
 
         void reset() override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDevice.hpp
@@ -17,7 +17,7 @@ namespace clove {
     private:
         DevicePointer devicePtr;
 
-        std::shared_ptr<VulkanFactory> factory;
+        std::unique_ptr<VulkanFactory> factory;
 
         //FUNCTIONS
     public:
@@ -32,7 +32,7 @@ namespace clove {
 
         ~VulkanDevice();
 
-        std::shared_ptr<GhaFactory> getGraphicsFactory() const override;
+        GhaFactory *getGraphicsFactory() const override;
 
         void waitForIdleDevice() override;
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanSwapchain.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanSwapchain.hpp
@@ -21,7 +21,7 @@ namespace clove {
         VkExtent2D swapChainExtent{};
 
         std::vector<VkImage> images;
-        std::vector<std::shared_ptr<VulkanImageView>> imageViews;
+        std::vector<std::unique_ptr<VulkanImageView>> imageViews;
 
         //FUNCTIONS
     public:
@@ -41,7 +41,7 @@ namespace clove {
         GhaImage::Format getImageFormat() const override;
         vec2ui getSize() const override;
 
-        std::vector<std::shared_ptr<GhaImageView>> getImageViews() const override;
+        std::vector<GhaImageView *> getImageViews() const override;
 
         VkSwapchainKHR getSwapchain() const;
     };

--- a/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
@@ -32,10 +32,10 @@ namespace clove {
                 auto const &submission{ submissions[i] };
                 bool const isLastSubmission{ i == submissions.size() - 1 };
                 
-                for(auto const &commandBuffer : submission.commandBuffers) {
+                for(auto *commandBuffer : submission.commandBuffers) {
                     bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
                     
-                    auto *metalCommandBuffer{ polyCast<MetalComputeCommandBuffer>(commandBuffer.get()) };
+                    auto *metalCommandBuffer{ polyCast<MetalComputeCommandBuffer>(commandBuffer) };
                     if(metalCommandBuffer == nullptr) {
                         CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
@@ -51,7 +51,7 @@ namespace clove {
                     
                     //Inject the wait semaphore into each buffer
                     for (auto const &semaphore : submission.waitSemaphores) {
-                        auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first.get()) };
+                        auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                         if(metalSemaphore == nullptr) {
                             CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                             continue;
@@ -68,7 +68,7 @@ namespace clove {
                     //For the last buffer add all semaphore signalling
                     if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
                         for(auto const &semaphore : submission.signalSemaphores) {
-                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore.get())->getFence()];
+                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
                         }
                     }
                     

--- a/clove/components/core/graphics/source/Metal/MetalDescriptorPool.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDescriptorPool.mm
@@ -65,21 +65,21 @@ namespace clove {
         return descriptor;
     }
     
-    std::shared_ptr<GhaDescriptorSet> MetalDescriptorPool::allocateDescriptorSets(std::shared_ptr<GhaDescriptorSetLayout> const &layout) {
-        return allocateDescriptorSets(std::vector{ layout })[0];
+    std::unique_ptr<GhaDescriptorSet> MetalDescriptorPool::allocateDescriptorSets(GhaDescriptorSetLayout const *const layout) {
+        return std::move(allocateDescriptorSets(std::vector{ layout })[0]);
     }
     
-    std::vector<std::shared_ptr<GhaDescriptorSet>> MetalDescriptorPool::allocateDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSetLayout>> const &layouts) {
+    std::vector<std::unique_ptr<GhaDescriptorSet>> MetalDescriptorPool::allocateDescriptorSets(std::vector<GhaDescriptorSetLayout const *> const &layouts) {
         @autoreleasepool{
             size_t const setNum{ layouts.size() };
             
-            std::vector<MetalDescriptorSetLayout *> metalDescriptorSets{};
+            std::vector<MetalDescriptorSetLayout const *> metalDescriptorSets{};
             metalDescriptorSets.reserve(setNum);
             for(size_t i{ 0 }; i < layouts.size(); ++i) {
-                metalDescriptorSets.emplace_back(polyCast<MetalDescriptorSetLayout>(layouts[i].get()));
+                metalDescriptorSets.emplace_back(polyCast<MetalDescriptorSetLayout const>(layouts[i]));
             }
             
-            std::vector<std::shared_ptr<GhaDescriptorSet>> descriptorSets{};
+            std::vector<std::unique_ptr<GhaDescriptorSet>> descriptorSets{};
             descriptorSets.reserve(setNum);
             for(size_t i{ 0 }; i < layouts.size(); ++i) {
                 id<MTLArgumentEncoder> vertexEncoder{ nullptr };
@@ -109,20 +109,20 @@ namespace clove {
                     [computeEncoder setArgumentBuffer:computeEncoderBuffer offset:0];
                 }
                 
-                descriptorSets.emplace_back(std::make_shared<MetalDescriptorSet>(vertexEncoder, vertexEncoderBuffer, pixelEncoder, pixelEncoderBuffer, computeEncoder, computeEncoderBuffer, layouts[i]));
+                descriptorSets.emplace_back(std::make_unique<MetalDescriptorSet>(vertexEncoder, vertexEncoderBuffer, pixelEncoder, pixelEncoderBuffer, computeEncoder, computeEncoderBuffer, layouts[i]));
             }
             
             return descriptorSets;
         }
     }
     
-    void MetalDescriptorPool::freeDescriptorSets(std::shared_ptr<GhaDescriptorSet> const &descriptorSet) {
+    void MetalDescriptorPool::freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) {
         freeDescriptorSets(std::vector{ descriptorSet });
     }
     
-    void MetalDescriptorPool::freeDescriptorSets(std::vector<std::shared_ptr<GhaDescriptorSet>> const &descriptorSets) {
+    void MetalDescriptorPool::freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) {
         for(auto const &descriptorSet : descriptorSets) {
-            auto const *const mtlDescriptorSet{ polyCast<MetalDescriptorSet>(descriptorSet.get()) };
+            auto const *const mtlDescriptorSet{ polyCast<MetalDescriptorSet const>(descriptorSet) };
             if(mtlDescriptorSet == nullptr) {
                 CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "{0}: Descriptor set provided is nullptr. Buffers might never be freed", CLOVE_FUNCTION_NAME);
                 continue;

--- a/clove/components/core/graphics/source/Metal/MetalDescriptorSet.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDescriptorSet.mm
@@ -8,14 +8,14 @@
 #include <Clove/Cast.hpp>
 
 namespace clove {
-    MetalDescriptorSet::MetalDescriptorSet(id<MTLArgumentEncoder> vertexEncoder, id<MTLBuffer> vertexEncoderBuffer, id<MTLArgumentEncoder> pixelEncoder, id<MTLBuffer> pixelEncoderBuffer, id<MTLArgumentEncoder> computeEncoder, id<MTLBuffer> computeEncoderBuffer, std::shared_ptr<GhaDescriptorSetLayout> layout)
+    MetalDescriptorSet::MetalDescriptorSet(id<MTLArgumentEncoder> vertexEncoder, id<MTLBuffer> vertexEncoderBuffer, id<MTLArgumentEncoder> pixelEncoder, id<MTLBuffer> pixelEncoderBuffer, id<MTLArgumentEncoder> computeEncoder, id<MTLBuffer> computeEncoderBuffer, GhaDescriptorSetLayout const *layout)
         : vertexEncoder{ vertexEncoder }
         , vertexEncoderBuffer{ vertexEncoderBuffer }
         , pixelEncoder{ pixelEncoder }
         , pixelEncoderBuffer{ pixelEncoderBuffer }
         , computeEncoder{ computeEncoder }
         , computeEncoderBuffer{ computeEncoderBuffer }
-        , layout{ std::move(layout) } {
+        , layout{ layout } {
     }
     
     MetalDescriptorSet::MetalDescriptorSet(MetalDescriptorSet &&other) noexcept = default;

--- a/clove/components/core/graphics/source/Metal/MetalDevice.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDevice.mm
@@ -24,7 +24,7 @@ namespace clove {
         
         [nsWindow setContentView:wrapper->view];
         
-        factory = std::make_shared<MetalFactory>(wrapper->device, wrapper->view);
+        factory = std::make_unique<MetalFactory>(wrapper->device, wrapper->view);
     }
     
     MetalDevice::MetalDevice(MetalDevice &&other) noexcept = default;
@@ -33,8 +33,8 @@ namespace clove {
     
     MetalDevice::~MetalDevice() = default;
     
-    std::shared_ptr<GhaFactory> MetalDevice::getGraphicsFactory() const {
-        return factory;
+    GhaFactory *MetalDevice::getGraphicsFactory() const {
+        return factory.get();
     }
     
     void MetalDevice::waitForIdleDevice() {

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
@@ -34,10 +34,10 @@ namespace clove {
                 auto const &submission{ submissions[i] };
                 bool const isLastSubmission{ i == submissions.size() - 1 };
                 
-                for(auto const &commandBuffer : submission.commandBuffers) {
+                for(auto *commandBuffer : submission.commandBuffers) {
                     bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
                     
-                    auto *metalCommandBuffer{ polyCast<MetalGraphicsCommandBuffer>(commandBuffer.get()) };
+                    auto *metalCommandBuffer{ polyCast<MetalGraphicsCommandBuffer>(commandBuffer) };
                     if(metalCommandBuffer == nullptr) {
                         CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
@@ -55,7 +55,7 @@ namespace clove {
                         
                         //Inject the wait semaphore into each buffer
                         for (auto const &semaphore : submission.waitSemaphores) {
-                            auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first.get()) };
+                            auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                             if(metalSemaphore == nullptr) {
                                 CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                                 continue;
@@ -75,7 +75,7 @@ namespace clove {
                         //For the last buffer add all semaphore signalling
                         if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
                             for(auto const &semaphore : submission.signalSemaphores) {
-                                [encoder updateFence:polyCast<MetalSemaphore const>(semaphore.get())->getFence()
+                                [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()
                                          afterStages:MTLRenderStageFragment];
                             }
                         }

--- a/clove/components/core/graphics/source/Metal/MetalPresentQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalPresentQueue.mm
@@ -21,20 +21,20 @@ namespace clove {
     
     Result MetalPresentQueue::present(PresentInfo const &presentInfo) {
         @autoreleasepool{
-            MetalSwapchain *swapchain{ polyCast<MetalSwapchain>(presentInfo.swapChain.get()) };
+            MetalSwapchain *const swapchain{ polyCast<MetalSwapchain>(presentInfo.swapChain) };
             if(swapchain == nullptr) {
                 //Upon receiving this error a new swapchain should be created. Hopefully fixing the nullptr
                 return Result::Error_SwapchainOutOfDate;
             }
             
-            id<MTLTexture> texture{ polyCast<MetalImageView>(swapchain->getImageViews()[presentInfo.imageIndex].get())->getTexture() };
+            id<MTLTexture> texture{ polyCast<MetalImageView const>(swapchain->getImageViews()[presentInfo.imageIndex])->getTexture() };
             id<CAMetalDrawable> drawable{ view.metalLayer.nextDrawable };
             
             id<MTLCommandBuffer> commandBuffer{ [commandQueue commandBuffer] };
             
             id<MTLBlitCommandEncoder> encoder{ [commandBuffer blitCommandEncoder] };
             for(auto const &semaphore : presentInfo.waitSemaphores) {
-                [encoder waitForFence:polyCast<MetalSemaphore const>(semaphore.get())->getFence()];
+                [encoder waitForFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
             }
             [encoder copyFromTexture:texture toTexture:drawable.texture];
             [encoder endEncoding];

--- a/clove/components/core/graphics/source/Metal/MetalSwapchain.mm
+++ b/clove/components/core/graphics/source/Metal/MetalSwapchain.mm
@@ -6,7 +6,7 @@
 #include <Clove/Log/Log.hpp>
 
 namespace clove {
-	MetalSwapchain::MetalSwapchain(std::vector<std::shared_ptr<GhaImage>> images, GhaImage::Format imageFormat, vec2ui imageSize)
+	MetalSwapchain::MetalSwapchain(std::vector<std::unique_ptr<GhaImage>> images, GhaImage::Format imageFormat, vec2ui imageSize)
 		: images{ std::move(images) }
 		, imageFormat{ imageFormat }
 		, imageSize{ imageSize } {
@@ -51,8 +51,15 @@ namespace clove {
 		return imageSize;
 	}
 
-	std::vector<std::shared_ptr<GhaImageView>> MetalSwapchain::getImageViews() const {
-		return imageViews;
+	std::vector<GhaImageView *> MetalSwapchain::getImageViews() const {
+        std::vector<GhaImageView *> views{};
+        views.reserve(imageViews.size());
+        
+        for(auto const &view : imageViews) {
+            views.push_back(view.get());
+        }
+        
+		return views;
 	}
 	
 	void MetalSwapchain::markIndexAsFree(uint32_t index) {

--- a/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
@@ -33,10 +33,10 @@ namespace clove {
                 auto const &submission{ submissions[i] };
                 bool const isLastSubmission{ i == submissions.size() - 1 };
                 
-                for(auto const &commandBuffer : submission.commandBuffers) {
+                for(auto *commandBuffer : submission.commandBuffers) {
                     bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
                     
-                    auto *metalCommandBuffer{ polyCast<MetalTransferCommandBuffer>(commandBuffer.get()) };
+                    auto *metalCommandBuffer{ polyCast<MetalTransferCommandBuffer>(commandBuffer) };
                     if(metalCommandBuffer == nullptr) {
                         CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
@@ -52,7 +52,7 @@ namespace clove {
                     
                     //Inject the wait semaphore into each buffer
                     for (auto const &semaphore : submission.waitSemaphores) {
-                        auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first.get()) };
+                        auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                         if(metalSemaphore == nullptr) {
                             CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                             continue;
@@ -69,7 +69,7 @@ namespace clove {
                     //For the last buffer add all semaphore signalling
                     if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
                         for(auto const &semaphore : submission.signalSemaphores) {
-                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore.get())->getFence()];
+                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
                         }
                     }
                     

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
@@ -65,7 +65,7 @@ namespace clove {
             waitStages[i].resize(waitSemaphoreCount);
 
             for(size_t j = 0; j < waitSemaphoreCount; ++j) {
-                waitSemaphores[i][j] = polyCast<VulkanSemaphore>(submissions[i].waitSemaphores[j].first.get())->getSemaphore();
+                waitSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].waitSemaphores[j].first)->getSemaphore();
                 waitStages[i][j]     = convertStage(submissions[i].waitSemaphores[j].second);
             }
 
@@ -73,14 +73,14 @@ namespace clove {
             size_t const commandBufferCount{ std::size(submissions[i].commandBuffers) };
             commandBuffers[i].resize(commandBufferCount);
             for(size_t j = 0; j < commandBufferCount; ++j) {
-                commandBuffers[i][j] = polyCast<VulkanComputeCommandBuffer>(submissions[i].commandBuffers[j].get())->getCommandBuffer();
+                commandBuffers[i][j] = polyCast<VulkanComputeCommandBuffer const>(submissions[i].commandBuffers[j])->getCommandBuffer();
             }
 
             //Signal semaphores
             size_t const signalSemaphoreCount{ std::size(submissions[i].signalSemaphores) };
             signalSemaphores[i].resize(signalSemaphoreCount);
             for(size_t j = 0; j < signalSemaphoreCount; ++j) {
-                signalSemaphores[i][j] = polyCast<VulkanSemaphore>(submissions[i].signalSemaphores[j].get())->getSemaphore();
+                signalSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].signalSemaphores[j])->getSemaphore();
             }
 
             vkSubmissions.emplace_back(VkSubmitInfo{

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -419,7 +419,7 @@ namespace clove {
         }
 
         devicePtr = DevicePointer{ instance, surface, physicalDevice, logicalDevice, debugMessenger };
-        factory   = std::make_shared<VulkanFactory>(devicePtr, queueFamilyIndices);
+        factory   = std::make_unique<VulkanFactory>(devicePtr, queueFamilyIndices);
     }
 
     VulkanDevice::VulkanDevice(VulkanDevice &&other) noexcept = default;
@@ -428,8 +428,8 @@ namespace clove {
 
     VulkanDevice::~VulkanDevice() = default;
 
-    std::shared_ptr<GhaFactory> VulkanDevice::getGraphicsFactory() const {
-        return factory;
+    GhaFactory *VulkanDevice::getGraphicsFactory() const {
+        return factory.get();
     }
 
     void VulkanDevice::waitForIdleDevice() {

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -541,7 +541,7 @@ namespace clove {
         size_t const descriptorLayoutCount{ std::size(descriptor.descriptorSetLayouts) };
         std::vector<VkDescriptorSetLayout> descriptorLayouts(descriptorLayoutCount);
         for(size_t i = 0; i < descriptorLayoutCount; ++i) {
-            descriptorLayouts[i] = polyCast<VulkanDescriptorSetLayout>(descriptor.descriptorSetLayouts[i].get())->getLayout();
+            descriptorLayouts[i] = polyCast<VulkanDescriptorSetLayout const>(descriptor.descriptorSetLayouts[i])->getLayout();
         }
 
         //Push constants
@@ -581,7 +581,7 @@ namespace clove {
         shaderStages[0] = VkPipelineShaderStageCreateInfo{
             .sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
             .stage  = VK_SHADER_STAGE_VERTEX_BIT,
-            .module = polyCast<VulkanShader>(descriptor.vertexShader.get())->getModule(),
+            .module = polyCast<VulkanShader const>(descriptor.vertexShader)->getModule(),
             .pName  = "main",
         };
 
@@ -589,7 +589,7 @@ namespace clove {
         shaderStages[1] = VkPipelineShaderStageCreateInfo{
             .sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
             .stage  = VK_SHADER_STAGE_FRAGMENT_BIT,
-            .module = polyCast<VulkanShader>(descriptor.pixelShader.get())->getModule(),
+            .module = polyCast<VulkanShader const>(descriptor.pixelShader)->getModule(),
             .pName  = "main",
         };
 
@@ -741,7 +741,7 @@ namespace clove {
             .pColorBlendState    = &colorBlending,
             .pDynamicState       = &dynamicViewportState,
             .layout              = pipelineLayout,
-            .renderPass          = polyCast<VulkanRenderPass>(descriptor.renderPass.get())->getRenderPass(),
+            .renderPass          = polyCast<VulkanRenderPass const>(descriptor.renderPass)->getRenderPass(),
             .subpass             = 0,//The subpass of the renderpass that'll use this pipeline
             .basePipelineHandle  = VK_NULL_HANDLE,
             .basePipelineIndex   = -1,
@@ -767,7 +767,7 @@ namespace clove {
         size_t const descriptorLayoutCount{ std::size(descriptor.descriptorSetLayouts) };
         std::vector<VkDescriptorSetLayout> descriptorLayouts(descriptorLayoutCount);
         for(size_t i = 0; i < descriptorLayoutCount; ++i) {
-            descriptorLayouts[i] = polyCast<VulkanDescriptorSetLayout>(descriptor.descriptorSetLayouts[i].get())->getLayout();
+            descriptorLayouts[i] = polyCast<VulkanDescriptorSetLayout const>(descriptor.descriptorSetLayouts[i])->getLayout();
         }
 
         //Push constants
@@ -805,7 +805,7 @@ namespace clove {
         VkPipelineShaderStageCreateInfo const shaderStage{
             .sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
             .stage  = VK_SHADER_STAGE_COMPUTE_BIT,
-            .module = polyCast<VulkanShader>(descriptor.shader.get())->getModule(),
+            .module = polyCast<VulkanShader const>(descriptor.shader)->getModule(),
             .pName  = "main",
         };
 
@@ -837,14 +837,14 @@ namespace clove {
         std::vector<VkImageView> attachments;
         attachments.reserve(std::size(descriptor.attachments));
         for(auto &attachment : descriptor.attachments) {
-            attachments.push_back(polyCast<VulkanImageView>(attachment.get())->getImageView());
+            attachments.push_back(polyCast<VulkanImageView const>(attachment)->getImageView());
         }
 
         VkFramebufferCreateInfo const framebufferInfo{
             .sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
             .pNext           = nullptr,
             .flags           = 0,
-            .renderPass      = polyCast<VulkanRenderPass>(descriptor.renderPass.get())->getRenderPass(),
+            .renderPass      = polyCast<VulkanRenderPass const>(descriptor.renderPass)->getRenderPass(),
             .attachmentCount = static_cast<uint32_t>(std::size(attachments)),
             .pAttachments    = std::data(attachments),
             .width           = descriptor.width,

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
@@ -50,7 +50,7 @@ namespace clove {
     }
 
     void VulkanGraphicsQueue::submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) {
-        auto const submissioncount{ std::size(submissions) };
+        size_t const submissioncount{ submissions.size() };
         std::vector<VkSubmitInfo> vkSubmissions;
         vkSubmissions.reserve(submissioncount);
 
@@ -66,7 +66,7 @@ namespace clove {
             waitStages[i].resize(waitSemaphoreCount);
 
             for(size_t j = 0; j < waitSemaphoreCount; ++j) {
-                waitSemaphores[i][j] = polyCast<VulkanSemaphore>(submissions[i].waitSemaphores[j].first.get())->getSemaphore();
+                waitSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].waitSemaphores[j].first)->getSemaphore();
                 waitStages[i][j]     = convertStage(submissions[i].waitSemaphores[j].second);
             }
 
@@ -74,14 +74,14 @@ namespace clove {
             size_t const commandBufferCount{ std::size(submissions[i].commandBuffers) };
             commandBuffers[i].resize(commandBufferCount);
             for(size_t j = 0; j < commandBufferCount; ++j) {
-                commandBuffers[i][j] = polyCast<VulkanGraphicsCommandBuffer>(submissions[i].commandBuffers[j].get())->getCommandBuffer();
+                commandBuffers[i][j] = polyCast<VulkanGraphicsCommandBuffer const>(submissions[i].commandBuffers[j])->getCommandBuffer();
             }
 
             //Signal semaphores
             size_t const signalSemaphoreCount{ std::size(submissions[i].signalSemaphores) };
             signalSemaphores[i].resize(signalSemaphoreCount);
             for(size_t j = 0; j < signalSemaphoreCount; ++j) {
-                signalSemaphores[i][j] = polyCast<VulkanSemaphore>(submissions[i].signalSemaphores[j].get())->getSemaphore();
+                signalSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].signalSemaphores[j])->getSemaphore();
             }
 
             vkSubmissions.emplace_back(VkSubmitInfo{

--- a/clove/components/core/graphics/source/Vulkan/VulkanPresentQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanPresentQueue.cpp
@@ -27,10 +27,10 @@ namespace clove {
         const size_t waitSemaphoreCount = std::size(presentInfo.waitSemaphores);
         std::vector<VkSemaphore> waitSemaphores(waitSemaphoreCount);
         for(size_t i = 0; i < waitSemaphoreCount; ++i) {
-            waitSemaphores[i] = polyCast<VulkanSemaphore>(presentInfo.waitSemaphores[i].get())->getSemaphore();
+            waitSemaphores[i] = polyCast<VulkanSemaphore const>(presentInfo.waitSemaphores[i])->getSemaphore();
         }
 
-        VkSwapchainKHR const swapchain{ polyCast<VulkanSwapchain>(presentInfo.swapChain.get())->getSwapchain() };
+        VkSwapchainKHR const swapchain{ polyCast<VulkanSwapchain const>(presentInfo.swapChain)->getSwapchain() };
         uint32_t const imageIndex{ presentInfo.imageIndex };
 
         VkPresentInfoKHR vkpresentInfo{

--- a/clove/components/core/graphics/source/Vulkan/VulkanSwapchain.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanSwapchain.cpp
@@ -20,7 +20,7 @@ namespace clove {
 
         imageViews.resize(std::size(images));
         for(size_t i = 0; i < images.size(); ++i) {
-            imageViews[i] = std::make_shared<VulkanImageView>(this->device.get(), VulkanImageView::create(this->device.get(), images[i], VK_IMAGE_VIEW_TYPE_2D, swapChainImageFormat, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1));
+            imageViews[i] = std::make_unique<VulkanImageView>(this->device.get(), VulkanImageView::create(this->device.get(), images[i], VK_IMAGE_VIEW_TYPE_2D, swapChainImageFormat, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1));
         }
     }
 
@@ -34,7 +34,7 @@ namespace clove {
 
     std::pair<uint32_t, Result> VulkanSwapchain::aquireNextImage(GhaSemaphore const *availableSemaphore) {
         uint32_t outImageIndex{ 0 };
-        VkSemaphore vkSemaphore{ availableSemaphore != nullptr ? polyCast<const VulkanSemaphore>(availableSemaphore)->getSemaphore() : VK_NULL_HANDLE };
+        VkSemaphore vkSemaphore{ availableSemaphore != nullptr ? polyCast<VulkanSemaphore const>(availableSemaphore)->getSemaphore() : VK_NULL_HANDLE };
         VkResult const result{ vkAcquireNextImageKHR(device.get(), swapchain, UINT64_MAX, vkSemaphore, VK_NULL_HANDLE, &outImageIndex) };
 
         return { outImageIndex, convertResult(result) };
@@ -48,8 +48,15 @@ namespace clove {
         return { swapChainExtent.width, swapChainExtent.height };
     }
 
-    std::vector<std::shared_ptr<GhaImageView>> VulkanSwapchain::getImageViews() const {
-        return { imageViews.begin(), imageViews.end() };
+    std::vector<GhaImageView *> VulkanSwapchain::getImageViews() const {
+        std::vector<GhaImageView *> views{};
+        views.reserve(imageViews.size());
+        
+        for(auto const &view : imageViews){
+            views.push_back(view.get());
+        }
+
+        return views;
     }
 
     VkSwapchainKHR VulkanSwapchain::getSwapchain() const {

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
@@ -69,7 +69,7 @@ namespace clove {
             waitStages[i].resize(waitSemaphoreCount);
 
             for(size_t j = 0; j < waitSemaphoreCount; ++j) {
-                waitSemaphores[i][j] = polyCast<VulkanSemaphore>(submissions[i].waitSemaphores[j].first.get())->getSemaphore();
+                waitSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].waitSemaphores[j].first)->getSemaphore();
                 waitStages[i][j]     = convertStage(submissions[i].waitSemaphores[j].second);
             }
 
@@ -77,14 +77,14 @@ namespace clove {
             size_t const commandBufferCount{ std::size(submissions[i].commandBuffers) };
             commandBuffers[i].resize(commandBufferCount);
             for(size_t j = 0; j < commandBufferCount; ++j) {
-                commandBuffers[i][j] = polyCast<VulkanTransferCommandBuffer>(submissions[i].commandBuffers[j].get())->getCommandBuffer();
+                commandBuffers[i][j] = polyCast<VulkanTransferCommandBuffer const>(submissions[i].commandBuffers[j])->getCommandBuffer();
             }
 
             //Signal semaphores
             size_t const signalSemaphoreCount{ std::size(submissions[i].signalSemaphores) };
             signalSemaphores[i].resize(signalSemaphoreCount);
             for(size_t j = 0; j < signalSemaphoreCount; ++j) {
-                signalSemaphores[i][j] = polyCast<VulkanSemaphore>(submissions[i].signalSemaphores[j].get())->getSemaphore();
+                signalSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].signalSemaphores[j])->getSemaphore();
             }
 
             vkSubmissions.emplace_back(VkSubmitInfo{

--- a/clove/include/Clove/Rendering/ForwardRenderer3D.hpp
+++ b/clove/include/Clove/Rendering/ForwardRenderer3D.hpp
@@ -75,32 +75,32 @@ namespace clove {
          * @brief Objects that hold the state / data of each image (in flight)
          */
         struct ImageData {
-            std::shared_ptr<GhaGraphicsCommandBuffer> commandBuffer;
-            std::shared_ptr<GhaGraphicsCommandBuffer> shadowMapCommandBuffer;
-            std::shared_ptr<GhaGraphicsCommandBuffer> cubeShadowMapCommandBuffer;
-            std::shared_ptr<GhaComputeCommandBuffer> skinningCommandBuffer;
+            std::unique_ptr<GhaGraphicsCommandBuffer> commandBuffer;
+            std::unique_ptr<GhaGraphicsCommandBuffer> shadowMapCommandBuffer;
+            std::unique_ptr<GhaGraphicsCommandBuffer> cubeShadowMapCommandBuffer;
+            std::unique_ptr<GhaComputeCommandBuffer> skinningCommandBuffer;
 
-            std::shared_ptr<GhaBuffer> frameDataBuffer;            /**< Holds data used across all meshes (lighting, camera etc.). */
+            std::unique_ptr<GhaBuffer> frameDataBuffer;            /**< Holds data used across all meshes (lighting, camera etc.). */
             std::vector<std::unique_ptr<GhaBuffer>> objectBuffers; /**< Holds the data for each object. */
 
-            std::shared_ptr<GhaDescriptorPool> frameDescriptorPool; /**< Descriptor pool for sets that change per frame. */
-            std::shared_ptr<GhaDescriptorPool> meshDescriptorPool;  /**< Descriptor pool for sets that are for a single mesh's material. */
-            std::shared_ptr<GhaDescriptorPool> uiDescriptorPool;    /**< Descriptor pool for sets that are for a ui element. */
-            std::shared_ptr<GhaDescriptorPool> skinningDescriptorPool;
+            std::unique_ptr<GhaDescriptorPool> frameDescriptorPool; /**< Descriptor pool for sets that change per frame. */
+            std::unique_ptr<GhaDescriptorPool> meshDescriptorPool;  /**< Descriptor pool for sets that are for a single mesh's material. */
+            std::unique_ptr<GhaDescriptorPool> uiDescriptorPool;    /**< Descriptor pool for sets that are for a ui element. */
+            std::unique_ptr<GhaDescriptorPool> skinningDescriptorPool;
 
-            std::shared_ptr<GhaDescriptorSet> viewDescriptorSet;
-            std::shared_ptr<GhaDescriptorSet> lightingDescriptorSet;
-            std::shared_ptr<GhaDescriptorSet> uiDescriptorSet;
+            std::unique_ptr<GhaDescriptorSet> viewDescriptorSet;
+            std::unique_ptr<GhaDescriptorSet> lightingDescriptorSet;
+            std::unique_ptr<GhaDescriptorSet> uiDescriptorSet;
 
-            std::shared_ptr<GhaImage> shadowMaps;
-            std::shared_ptr<GhaImageView> shadowMapViews;//View over entire array. For sampling in lighting shader.
-            std::array<std::shared_ptr<GhaImageView>, MAX_LIGHTS> shadowMapArrayLayerViews;//Views for each element of the array. For the frame buffer
-            std::array<std::shared_ptr<GhaFramebuffer>, MAX_LIGHTS> shadowMapFrameBuffers;
+            std::unique_ptr<GhaImage> shadowMaps;
+            std::unique_ptr<GhaImageView> shadowMapViews;//View over entire array. For sampling in lighting shader.
+            std::array<std::unique_ptr<GhaImageView>, MAX_LIGHTS> shadowMapArrayLayerViews;//Views for each element of the array. For the frame buffer
+            std::array<std::unique_ptr<GhaFramebuffer>, MAX_LIGHTS> shadowMapFrameBuffers;
 
-            std::shared_ptr<GhaImage> cubeShadowMaps;
-            std::shared_ptr<GhaImageView> cubeShadowMapViews;                                                           //Views the whole cube. For sampling in lighting shader.
-            std::array<std::array<std::shared_ptr<GhaImageView>, cubeMapLayerCount>, MAX_LIGHTS> cubeShadowMapFaceViews;//Views each side of the cube. For the frame buffer
-            std::array<std::array<std::shared_ptr<GhaFramebuffer>, cubeMapLayerCount>, MAX_LIGHTS> cubeShadowMapFrameBuffers;
+            std::unique_ptr<GhaImage> cubeShadowMaps;
+            std::unique_ptr<GhaImageView> cubeShadowMapViews;                                                           //Views the whole cube. For sampling in lighting shader.
+            std::array<std::array<std::unique_ptr<GhaImageView>, cubeMapLayerCount>, MAX_LIGHTS> cubeShadowMapFaceViews;//Views each side of the cube. For the frame buffer
+            std::array<std::array<std::unique_ptr<GhaFramebuffer>, cubeMapLayerCount>, MAX_LIGHTS> cubeShadowMapFrameBuffers;
         };
 
         //VARIABLES
@@ -113,48 +113,48 @@ namespace clove {
         DelegateHandle renderTargetPropertyChangedBeginHandle;
         DelegateHandle renderTargetPropertyChangedEndHandle;
         std::unique_ptr<RenderTarget> renderTarget;
-        std::vector<std::shared_ptr<GhaFramebuffer>> frameBuffers;//TODO: Move inside the ImageData
+        std::vector<std::unique_ptr<GhaFramebuffer>> frameBuffers;//TODO: Move inside the ImageData
 
         //'Square' mesh used to render UI
-        std::unique_ptr<Mesh> uiMesh;
+        std::shared_ptr<Mesh> uiMesh;
 
         GhaDevice *ghaDevice;
-        std::shared_ptr<GhaFactory> ghaFactory;
+        GhaFactory *ghaFactory;
 
-        std::shared_ptr<GhaGraphicsQueue> graphicsQueue;
-        std::shared_ptr<GhaComputeQueue> computeQueue;
+        std::unique_ptr<GhaGraphicsQueue> graphicsQueue;
+        std::unique_ptr<GhaComputeQueue> computeQueue;
 
-        std::unordered_map<DescriptorSetSlots, std::shared_ptr<GhaDescriptorSetLayout>> descriptorSetLayouts;
-        std::shared_ptr<GhaDescriptorSetLayout> skinningSetLayout;
+        std::unordered_map<DescriptorSetSlots, std::unique_ptr<GhaDescriptorSetLayout>> descriptorSetLayouts;
+        std::unique_ptr<GhaDescriptorSetLayout> skinningSetLayout;
 
         //Frame / image data objects
         FrameData currentFrameData;
         std::vector<ImageData> inFlightImageData;
 
         //Samplers passed along with textures
-        std::shared_ptr<GhaSampler> textureSampler;
-        std::shared_ptr<GhaSampler> uiSampler;
-        std::shared_ptr<GhaSampler> shadowSampler;
+        std::unique_ptr<GhaSampler> textureSampler;
+        std::unique_ptr<GhaSampler> uiSampler;
+        std::unique_ptr<GhaSampler> shadowSampler;
 
         //Geometry passes. TODO: Use vector?
         std::unordered_map<GeometryPass::Id, std::unique_ptr<GeometryPass>> geometryPasses;
 
         //Objects for the final colour render pass
-        std::shared_ptr<GhaRenderPass> renderPass;
-        std::shared_ptr<GhaGraphicsPipelineObject> widgetPipelineObject;
-        std::shared_ptr<GhaGraphicsPipelineObject> textPipelineObject;
+        std::unique_ptr<GhaRenderPass> renderPass;
+        std::unique_ptr<GhaGraphicsPipelineObject> widgetPipelineObject;
+        std::unique_ptr<GhaGraphicsPipelineObject> textPipelineObject;
 
-        std::shared_ptr<GhaImage> depthImage;
-        std::shared_ptr<GhaImageView> depthImageView;
+        std::unique_ptr<GhaImage> depthImage;
+        std::unique_ptr<GhaImageView> depthImageView;
 
         //Objects for the shadow map pass
-        std::shared_ptr<GhaRenderPass> shadowMapRenderPass;
+        std::unique_ptr<GhaRenderPass> shadowMapRenderPass;
 
         //Synchronisation obects
-        std::array<std::shared_ptr<GhaSemaphore>, maxFramesInFlight> skinningFinishedSemaphores;
+        std::array<std::unique_ptr<GhaSemaphore>, maxFramesInFlight> skinningFinishedSemaphores;
 
         //TEMP: Compute skinning objects -- Put inside a GeometryPass
-        std::shared_ptr<GhaComputePipelineObject> skinningPipeline;
+        std::unique_ptr<GhaComputePipelineObject> skinningPipeline;
 
         //FUNCTIONS
     public:
@@ -165,7 +165,7 @@ namespace clove {
         //ForwardRenderer3D(ForwardRenderer3D&& other) noexcept;
 
         ForwardRenderer3D &operator=(ForwardRenderer3D const &other) = delete;
-        ForwardRenderer3D &operator                                  =(ForwardRenderer3D &&other) noexcept;
+        ForwardRenderer3D &operator=(ForwardRenderer3D &&other) noexcept;
 
         ~ForwardRenderer3D();
 
@@ -199,6 +199,6 @@ namespace clove {
 
         void createRenderTargetFrameBuffers();
 
-        std::shared_ptr<GhaDescriptorPool> createDescriptorPool(std::unordered_map<DescriptorType, uint32_t> const &bindingCount, uint32_t const setCount);
+        std::unique_ptr<GhaDescriptorPool> createDescriptorPool(std::unordered_map<DescriptorType, uint32_t> const &bindingCount, uint32_t const setCount);
     };
 }

--- a/clove/include/Clove/Rendering/GraphicsImageRenderTarget.hpp
+++ b/clove/include/Clove/Rendering/GraphicsImageRenderTarget.hpp
@@ -26,7 +26,7 @@ namespace clove {
     private:
         GhaImage::Descriptor imageDescriptor{};
 
-        GhaFactory *factory;
+        GhaFactory *factory{ nullptr };
 
         std::unique_ptr<GhaGraphicsQueue> graphicsQueue;
         std::unique_ptr<GhaTransferQueue> transferQueue;

--- a/clove/include/Clove/Rendering/GraphicsImageRenderTarget.hpp
+++ b/clove/include/Clove/Rendering/GraphicsImageRenderTarget.hpp
@@ -26,25 +26,25 @@ namespace clove {
     private:
         GhaImage::Descriptor imageDescriptor{};
 
-        std::shared_ptr<GhaFactory> factory;
+        GhaFactory *factory;
 
-        std::shared_ptr<GhaGraphicsQueue> graphicsQueue;
-        std::shared_ptr<GhaTransferQueue> transferQueue;
-        std::shared_ptr<GhaTransferCommandBuffer> transferCommandBuffer;
+        std::unique_ptr<GhaGraphicsQueue> graphicsQueue;
+        std::unique_ptr<GhaTransferQueue> transferQueue;
+        std::unique_ptr<GhaTransferCommandBuffer> transferCommandBuffer;
 
-        std::shared_ptr<GhaSemaphore> renderFinishedSemaphore;
-        std::shared_ptr<GhaFence> frameInFlight;
+        std::unique_ptr<GhaSemaphore> renderFinishedSemaphore;
+        std::unique_ptr<GhaFence> frameInFlight;
 
-        std::shared_ptr<GhaImage> renderTargetImage;
-        std::shared_ptr<GhaImageView> renderTargetView;
-        std::shared_ptr<GhaBuffer> renderTargetBuffer;
+        std::unique_ptr<GhaImage> renderTargetImage;
+        std::unique_ptr<GhaImageView> renderTargetView;
+        std::unique_ptr<GhaBuffer> renderTargetBuffer;
 
         bool requiresResize{ false };
 
         //FUNCTIONS
     public:
         GraphicsImageRenderTarget() = delete;
-        GraphicsImageRenderTarget(GhaImage::Descriptor imageDescriptor, std::shared_ptr<GhaFactory> factory);
+        GraphicsImageRenderTarget(GhaImage::Descriptor imageDescriptor, GhaFactory *factory);
 
         GraphicsImageRenderTarget(GraphicsImageRenderTarget const &other) = delete;
         GraphicsImageRenderTarget(GraphicsImageRenderTarget &&other) noexcept;
@@ -61,14 +61,15 @@ namespace clove {
         GhaImage::Format getImageFormat() const override;
         vec2ui getSize() const override;
 
-        std::vector<std::shared_ptr<GhaImageView>> getImageViews() const override;
+        std::vector<GhaImageView *> getImageViews() const override;
 
         void resize(vec2ui size);
 
         /**
          * @brief Returns a buffer containing the data of a recently written to image.
+         * The lifetime of the buffer is tied to this object.
          */
-        std::shared_ptr<GhaBuffer> getNextReadyBuffer();
+        GhaBuffer *getNextReadyBuffer();
 
     private:
         void createImages();

--- a/clove/include/Clove/Rendering/RenderPasses/DirectionalLightPass.hpp
+++ b/clove/include/Clove/Rendering/RenderPasses/DirectionalLightPass.hpp
@@ -19,7 +19,7 @@ namespace clove {
         //FUNCTIONS
     public:
         DirectionalLightPass() = delete;
-        DirectionalLightPass(GhaFactory &ghaFactory, std::shared_ptr<GhaRenderPass> ghaRenderPass);//TEMP: Using an external render pass for now but these pass will need to create their own
+        DirectionalLightPass(GhaFactory &ghaFactory, GhaRenderPass *ghaRenderPass);//TEMP: Using an external render pass for now but these pass will need to create their own
 
         DirectionalLightPass(DirectionalLightPass const &other) = delete;
         DirectionalLightPass(DirectionalLightPass &&other) noexcept;

--- a/clove/include/Clove/Rendering/RenderPasses/ForwardColourPass.hpp
+++ b/clove/include/Clove/Rendering/RenderPasses/ForwardColourPass.hpp
@@ -19,7 +19,7 @@ namespace clove {
         //FUNCTIONS
     public:
         ForwardColourPass() = delete;
-        ForwardColourPass(GhaFactory &ghaFactory, std::shared_ptr<GhaRenderPass> ghaRenderPass);//TEMP: Using an external render pass for now but these pass will need to create their own
+        ForwardColourPass(GhaFactory &ghaFactory, GhaRenderPass* ghaRenderPass);//TEMP: Using an external render pass for now but these pass will need to create their own
 
         ForwardColourPass(ForwardColourPass const &other) = delete;
         ForwardColourPass(ForwardColourPass &&other) noexcept;

--- a/clove/include/Clove/Rendering/RenderPasses/GeometryPass.hpp
+++ b/clove/include/Clove/Rendering/RenderPasses/GeometryPass.hpp
@@ -28,11 +28,11 @@ namespace clove {
          * @brief Data a GeometryPass will need for a given frame.
          */
         struct FrameData {
-            std::vector<std::shared_ptr<GhaDescriptorSet>> meshDescriptorSets{}; /**< Descriptor set for each mesh submitted for the frame. */
-            std::vector<std::shared_ptr<GhaDescriptorSet>> skinningMeshSets{};
+            std::vector<GhaDescriptorSet *> meshDescriptorSets{}; /**< Descriptor set for each mesh submitted for the frame. */
+            std::vector<GhaDescriptorSet *> skinningMeshSets{};
 
-            std::shared_ptr<GhaDescriptorSet> viewDescriptorSet{ nullptr };     /**< Descriptor set for view specific data. */
-            std::shared_ptr<GhaDescriptorSet> lightingDescriptorSet{ nullptr }; /**< Descriptor set for lighting specific data. */
+            GhaDescriptorSet *viewDescriptorSet{ nullptr };     /**< Descriptor set for view specific data. */
+            GhaDescriptorSet *lightingDescriptorSet{ nullptr }; /**< Descriptor set for lighting specific data. */
 
             //TODO: This is specific to the light passes. Should it be in here?
             mat4f *currentDirLightTransform{ nullptr };

--- a/clove/include/Clove/Rendering/RenderPasses/PointLightPass.hpp
+++ b/clove/include/Clove/Rendering/RenderPasses/PointLightPass.hpp
@@ -19,7 +19,7 @@ namespace clove {
         //FUNCTIONS
     public:
         PointLightPass() = delete;
-        PointLightPass(GhaFactory &ghaFactory, std::shared_ptr<GhaRenderPass> ghaRenderPass);//TEMP: Using an external render pass for now but these pass will need to create their own
+        PointLightPass(GhaFactory &ghaFactory, GhaRenderPass *ghaRenderPass);//TEMP: Using an external render pass for now but these pass will need to create their own
 
         PointLightPass(PointLightPass const &other) = delete;
         PointLightPass(PointLightPass &&other) noexcept;

--- a/clove/include/Clove/Rendering/RenderTarget.hpp
+++ b/clove/include/Clove/Rendering/RenderTarget.hpp
@@ -56,11 +56,16 @@ namespace clove {
          * number will be from 0 - N-1 where N is the total number of frames in flight.
          * @param submission The graphics queue submission that uses the imageIndex image.
          */
-        virtual void submit(uint32_t imageIndex, size_t const frameId, clove::GraphicsSubmitInfo submission) = 0;
+        virtual void submit(uint32_t imageIndex, size_t const frameId, GraphicsSubmitInfo submission) = 0;
 
-        virtual clove::GhaImage::Format getImageFormat() const = 0;
-        virtual vec2ui getSize() const                                      = 0;
+        virtual GhaImage::Format getImageFormat() const = 0;
+        virtual vec2ui getSize() const                  = 0;
 
-        virtual std::vector<std::shared_ptr<clove::GhaImageView>> getImageViews() const = 0;
+        /**
+         * @brief Returns the image views backing this RenderTarget. The lifetime of the views
+         * are tied to this object.
+         * @return 
+         */
+        virtual std::vector<GhaImageView *> getImageViews() const = 0;
     };
 }

--- a/clove/include/Clove/Rendering/Renderables/Mesh.hpp
+++ b/clove/include/Clove/Rendering/Renderables/Mesh.hpp
@@ -2,6 +2,8 @@
 
 #include "Clove/Rendering/Vertex.hpp"
 
+#include <memory>
+
 namespace clove {
     class GhaBuffer;
     class VertexLayout;
@@ -17,11 +19,11 @@ namespace clove {
         /**
          * @brief Buffer containing the bind pose vertices of this mesh.
          */
-        std::shared_ptr<GhaBuffer> vertexBuffer;
+        std::unique_ptr<GhaBuffer> vertexBuffer;
         /**
          * @brief Buffer container both the indices and skinned vertices of this mesh.
          */
-        std::shared_ptr<GhaBuffer> combinedBuffer;
+        std::unique_ptr<GhaBuffer> combinedBuffer;
 
         std::vector<Vertex> vertices;
         std::vector<uint16_t> indices;
@@ -45,17 +47,19 @@ namespace clove {
 
         /**
          * @brief Returns the GhaBuffer containing just the vertices.
+         * The lifetime of the buffer is tied to this object.
          * @details This buffer contains the bind pose vertices for the
          * mesh. Before any skinning has taken place.
          */
-        inline std::shared_ptr<GhaBuffer> const &getVertexBuffer() const;
+        inline GhaBuffer *getVertexBuffer() const;
 
         /**
          * @brief Returns a GhaBuffer containing both vertices and indices.
+         * The lifetime of the buffer is tied to this object.
          * @details The vertices in this buffer are pre-skinned and are safe
          * to use straight away for animated meshes.
          */
-        inline std::shared_ptr<GhaBuffer> const &getCombinedBuffer() const;
+        inline GhaBuffer *getCombinedBuffer() const;
 
         /**
          * @brief Returns the offset into the combinedBuffer for the vertices.

--- a/clove/include/Clove/Rendering/Renderables/Mesh.inl
+++ b/clove/include/Clove/Rendering/Renderables/Mesh.inl
@@ -1,10 +1,10 @@
 namespace clove {
-    std::shared_ptr<GhaBuffer> const &Mesh::getVertexBuffer() const {
-        return vertexBuffer;
+    GhaBuffer *Mesh::getVertexBuffer() const {
+        return vertexBuffer.get();
     }
 
-    std::shared_ptr<GhaBuffer> const &Mesh::getCombinedBuffer() const {
-        return combinedBuffer;
+    GhaBuffer *Mesh::getCombinedBuffer() const {
+        return combinedBuffer.get();
     }
 
     size_t Mesh::getVertexOffset() const {

--- a/clove/include/Clove/Rendering/SwapchainRenderTarget.hpp
+++ b/clove/include/Clove/Rendering/SwapchainRenderTarget.hpp
@@ -23,16 +23,16 @@ namespace clove {
         //VARIABLES
     private:
         GhaDevice *graphicsDevice{ nullptr };
-        std::shared_ptr<GhaFactory> graphicsFactory;
+        GhaFactory *graphicsFactory{ nullptr };
 
-        std::shared_ptr<GhaSwapchain> swapchain;
-        std::shared_ptr<GhaPresentQueue> presentQueue;
-        std::shared_ptr<GhaGraphicsQueue> graphicsQueue;
+        std::unique_ptr<GhaSwapchain> swapchain;
+        std::unique_ptr<GhaPresentQueue> presentQueue;
+        std::unique_ptr<GhaGraphicsQueue> graphicsQueue;
 
-        std::vector<std::shared_ptr<GhaSemaphore>> renderFinishedSemaphores;
-        std::vector<std::shared_ptr<GhaSemaphore>> imageAvailableSemaphores;
-        std::vector<std::shared_ptr<GhaFence>> framesInFlight;
-        std::vector<std::shared_ptr<GhaFence>> imagesInFlight;
+        std::vector<std::unique_ptr<GhaSemaphore>> renderFinishedSemaphores;
+        std::vector<std::unique_ptr<GhaSemaphore>> imageAvailableSemaphores;
+        std::vector<std::unique_ptr<GhaFence>> framesInFlight;
+        std::vector<GhaFence *> imagesInFlight;
 
         vec2ui surfaceSize{};
         DelegateHandle surfaceResizeHandle;
@@ -59,7 +59,7 @@ namespace clove {
         GhaImage::Format getImageFormat() const override;
         vec2ui getSize() const override;
 
-        std::vector<std::shared_ptr<GhaImageView>> getImageViews() const override;
+        std::vector<GhaImageView *> getImageViews() const override;
 
     private:
         void onSurfaceSizeChanged(vec2ui const &size);

--- a/clove/source/Rendering/RenderPasses/DirectionalLightPass.cpp
+++ b/clove/source/Rendering/RenderPasses/DirectionalLightPass.cpp
@@ -55,7 +55,7 @@ namespace clove {
             .viewportDescriptor   = viewScissorArea,
             .scissorDescriptor    = viewScissorArea,
             .enableBlending       = false,
-            .renderPass           = std::move(ghaRenderPass),
+            .renderPass           = ghaRenderPass,
             .descriptorSetLayouts = {
                 meshLayout.get(),
             },

--- a/clove/source/Rendering/RenderPasses/DirectionalLightPass.cpp
+++ b/clove/source/Rendering/RenderPasses/DirectionalLightPass.cpp
@@ -18,7 +18,7 @@ extern "C" const char meshshadowmap_p[];
 extern "C" const size_t meshshadowmap_pLength;
 
 namespace clove {
-    DirectionalLightPass::DirectionalLightPass(GhaFactory &ghaFactory, std::shared_ptr<GhaRenderPass> ghaRenderPass) {
+    DirectionalLightPass::DirectionalLightPass(GhaFactory &ghaFactory, GhaRenderPass *ghaRenderPass) {
         //Build include map
         std::unordered_map<std::string, std::string> shaderIncludes;
         shaderIncludes["Constants.glsl"] = { constants, constantsLength };
@@ -42,9 +42,14 @@ namespace clove {
             .size     = { shadowMapSize, shadowMapSize }
         };
 
+        auto vertShader{ *ghaFactory.createShaderFromSource({ meshshadowmap_v, meshshadowmap_vLength }, shaderIncludes, "Shadow Map - Animated Mesh (vertex)", GhaShader::Stage::Vertex) };
+        auto pixelShader{ *ghaFactory.createShaderFromSource({ meshshadowmap_p, meshshadowmap_pLength }, shaderIncludes, "Shadow Map (pixel)", GhaShader::Stage::Pixel) };
+
+        auto meshLayout{ createMeshDescriptorSetLayout(ghaFactory) };
+
         pipeline = *ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
-            .vertexShader         = *ghaFactory.createShaderFromSource({ meshshadowmap_v, meshshadowmap_vLength }, shaderIncludes, "Shadow Map - Animated Mesh (vertex)", GhaShader::Stage::Vertex),
-            .pixelShader          = *ghaFactory.createShaderFromSource({ meshshadowmap_p, meshshadowmap_pLength }, shaderIncludes, "Shadow Map (pixel)", GhaShader::Stage::Pixel),
+            .vertexShader         = vertShader.get(),
+            .pixelShader          = pixelShader.get(),
             .vertexInput          = Vertex::getInputBindingDescriptor(),
             .vertexAttributes     = vertexAttributes,
             .viewportDescriptor   = viewScissorArea,
@@ -52,7 +57,7 @@ namespace clove {
             .enableBlending       = false,
             .renderPass           = std::move(ghaRenderPass),
             .descriptorSetLayouts = {
-                createMeshDescriptorSetLayout(ghaFactory),
+                meshLayout.get(),
             },
             .pushConstants = {
                 pushConstant,

--- a/clove/source/Rendering/RenderPasses/PointLightPass.cpp
+++ b/clove/source/Rendering/RenderPasses/PointLightPass.cpp
@@ -61,7 +61,7 @@ namespace clove {
             .viewportDescriptor   = viewScissorArea,
             .scissorDescriptor    = viewScissorArea,
             .enableBlending       = false,
-            .renderPass           = std::move(ghaRenderPass),
+            .renderPass           = ghaRenderPass,
             .descriptorSetLayouts = {
                 meshLayout.get(),
             },

--- a/clove/source/Rendering/RenderPasses/SkinningPass.cpp
+++ b/clove/source/Rendering/RenderPasses/SkinningPass.cpp
@@ -24,15 +24,19 @@ namespace clove {
 			.stage = GhaShader::Stage::Compute,
 			.size  = sizeof(size_t),
 		};
-		
+
+        auto shader{ *ghaFactory.createShaderFromSource({ skinning_c, skinning_cLength }, shaderIncludes, "Skinning (compute)", GhaShader::Stage::Compute) };
+
+        auto skinningLayout{ createSkinningDescriptorSetLayout(ghaFactory) };
+
         GhaComputePipelineObject::Descriptor const skinningPipelineDescriptor{
-            .shader               = *ghaFactory.createShaderFromSource({ skinning_c, skinning_cLength }, shaderIncludes, "Skinning (compute)", GhaShader::Stage::Compute),
-			.descriptorSetLayouts = {
-                createSkinningDescriptorSetLayout(ghaFactory),
+            .shader               = shader.get(),
+            .descriptorSetLayouts = {
+                skinningLayout.get(),
             },
-			.pushConstants = {
-				pushConstant,
-			},
+            .pushConstants = {
+                pushConstant,
+            },
         };
 
         pipeline = *ghaFactory.createComputePipelineObject(skinningPipelineDescriptor);

--- a/clove/source/Rendering/Renderables/Mesh.cpp
+++ b/clove/source/Rendering/Renderables/Mesh.cpp
@@ -11,7 +11,7 @@ namespace clove {
             GhaFactory &factory{ *Application::get().getGraphicsDevice()->getGraphicsFactory() };
 
             auto transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
-            std::shared_ptr<GhaTransferCommandBuffer> transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
+            auto transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
 
             transferCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
             transferCommandBuffer->copyBufferToBuffer(source, 0, dest, 0, size);
@@ -19,7 +19,7 @@ namespace clove {
 
             auto transferQueueFinishedFence{ *factory.createFence({ false }) };
 
-            transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer } } }, transferQueueFinishedFence.get());
+            transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
 
             transferQueueFinishedFence->wait();
             transferQueue->freeCommandBuffer(*transferCommandBuffer);
@@ -77,7 +77,7 @@ namespace clove {
 
         auto transferQueueFinishedFence{ *factory.createFence({ false }) };
 
-        transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer } } }, transferQueueFinishedFence.get());
+        transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
 
         transferQueueFinishedFence->wait();
         transferQueue->freeCommandBuffer(*transferCommandBuffer);
@@ -89,11 +89,11 @@ namespace clove {
         , vertexOffset{ other.vertexOffset }
         , vertexBufferSize{ other.vertexBufferSize }
         , indexOffset{ other.indexOffset } {
-        //Can share vertex buffer as this should never change
-        vertexBuffer = other.vertexBuffer;
+
+        copyFullBuffer(*other.vertexBuffer, *vertexBuffer, vertexBufferSize);
 
         //Create a copy of the combined buffer as this will change per mesh
-        size_t const indexBufferSize{ sizeof(uint16_t) * this->indices.size() };
+        size_t const indexBufferSize{ sizeof(uint16_t) * indices.size() };
         size_t const totalSize{ vertexBufferSize + indexBufferSize };
 
         copyFullBuffer(*other.combinedBuffer, *combinedBuffer, totalSize);
@@ -108,11 +108,10 @@ namespace clove {
         vertexBufferSize = other.vertexBufferSize;
         indexOffset      = other.indexOffset;
 
-        //Can share vertex buffer as this should never change
-        vertexBuffer = other.vertexBuffer;
+        copyFullBuffer(*other.vertexBuffer, *vertexBuffer, vertexBufferSize);
 
         //Create a copy of the combined buffer as this will change per mesh
-        size_t const indexBufferSize{ sizeof(uint16_t) * this->indices.size() };
+        size_t const indexBufferSize{ sizeof(uint16_t) * indices.size() };
         size_t const totalSize{ vertexBufferSize + indexBufferSize };
 
         copyFullBuffer(*other.combinedBuffer, *combinedBuffer, totalSize);

--- a/clove/source/Rendering/RenderingHelpers.cpp
+++ b/clove/source/Rendering/RenderingHelpers.cpp
@@ -236,11 +236,11 @@ namespace clove {
         vec3i constexpr imageOffset{ 0, 0, 0 };
         vec3ui const imageExtent{ imageDescriptor.dimensions.x, imageDescriptor.dimensions.y, 1 };
 
-        auto transferQueue = *factory.createTransferQueue({ QueueFlags::Transient });
-        auto graphicsQueue = *factory.createGraphicsQueue({ QueueFlags::Transient });
+        auto transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
+        auto graphicsQueue{ *factory.createGraphicsQueue({ QueueFlags::Transient }) };
 
-        std::shared_ptr<GhaTransferCommandBuffer> transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
-        std::shared_ptr<GhaGraphicsCommandBuffer> graphicsCommandBuffer{ graphicsQueue->allocateCommandBuffer() };
+        auto transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
+        auto graphicsCommandBuffer{ graphicsQueue->allocateCommandBuffer() };
 
         auto image{ *factory.createImage(imageDescriptor) };
 
@@ -267,8 +267,8 @@ namespace clove {
         auto transferQueueFinishedFence{ *factory.createFence({ false }) };
         auto graphicsQueueFinishedFence{ *factory.createFence({ false }) };
 
-        transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer } } }, transferQueueFinishedFence.get());
-        graphicsQueue->submit({ GraphicsSubmitInfo{ .commandBuffers = { graphicsCommandBuffer } } }, graphicsQueueFinishedFence.get());
+        transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
+        graphicsQueue->submit({ GraphicsSubmitInfo{ .commandBuffers = { graphicsCommandBuffer.get() } } }, graphicsQueueFinishedFence.get());
 
         transferQueueFinishedFence->wait();
         transferQueue->freeCommandBuffer(*transferCommandBuffer);

--- a/clove/source/Rendering/SwapchainRenderTarget.cpp
+++ b/clove/source/Rendering/SwapchainRenderTarget.cpp
@@ -63,7 +63,7 @@ namespace clove {
         if(imagesInFlight[imageIndex] != nullptr) {
             imagesInFlight[imageIndex]->wait();
         }
-        imagesInFlight[imageIndex] = framesInFlight[frameId];
+        imagesInFlight[imageIndex] = framesInFlight[frameId].get();
 
         framesInFlight[frameId]->reset();
 
@@ -76,14 +76,14 @@ namespace clove {
         }
 
         //Inject the sempahores we use to synchronise with the swapchain and present queue
-        submission.waitSemaphores.emplace_back(imageAvailableSemaphores[frameId], PipelineStage::ColourAttachmentOutput);
-        submission.signalSemaphores.push_back(renderFinishedSemaphores[frameId]);
+        submission.waitSemaphores.emplace_back(imageAvailableSemaphores[frameId].get(), PipelineStage::ColourAttachmentOutput);
+        submission.signalSemaphores.push_back(renderFinishedSemaphores[frameId].get());
 
         graphicsQueue->submit({ std::move(submission) }, framesInFlight[frameId].get());
 
         auto const result = presentQueue->present(PresentInfo{
-            .waitSemaphores = { renderFinishedSemaphores[frameId] },
-            .swapChain      = swapchain,
+            .waitSemaphores = { renderFinishedSemaphores[frameId].get() },
+            .swapChain      = swapchain.get(),
             .imageIndex     = imageIndex,
         });
 
@@ -100,7 +100,7 @@ namespace clove {
         return swapchain->getSize();
     }
 
-    std::vector<std::shared_ptr<GhaImageView>> SwapchainRenderTarget::getImageViews() const {
+    std::vector<GhaImageView *> SwapchainRenderTarget::getImageViews() const {
         return swapchain->getImageViews();
     }
 


### PR DESCRIPTION
## Summary
Removed all `shared_ptr`s from GHA object descriptors and any AHA and GHA function arguments that don't need shared ownership

Closes #309 

## Changes
- Updated GHA api to not use shared_ptr in descriptors and some functions
- Update AhaSource to take ownership of the buffers it queues