### PR TITLE
Console sink now always prints Debug logs and up

### DIFF
--- a/clove/components/utilities/log/CMakeLists.txt
+++ b/clove/components/utilities/log/CMakeLists.txt
@@ -1,8 +1,5 @@
 option(CLOVE_ENABLE_ASSERTIONS "Enables the CLOVE_ASSERT macro. Allowing the program to debug break if certain conditions fail." ON)
 
-set(CLOVE_LOG_LEVEL 0 CACHE STRING "Sets the level for logs allowed to output in the console. 0 (default) is info and up, 1 is debug and up and 2 is all.")
-set_property(CACHE CLOVE_LOG_LEVEL PROPERTY STRINGS 0 1 2)
-
 set(INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/Clove/Log)
 set(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 
@@ -38,7 +35,4 @@ target_compile_definitions(
 
 	PUBLIC
 		CLOVE_ENABLE_ASSERTIONS=$<BOOL:${CLOVE_ENABLE_ASSERTIONS}>
-
-	PRIVATE
-		CLOVE_LOG_LEVEL=${CLOVE_LOG_LEVEL}
 )

--- a/clove/components/utilities/log/include/Clove/Log/Log.hpp
+++ b/clove/components/utilities/log/include/Clove/Log/Log.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
+#include <Clove/Definitions.hpp>
 #include <memory>
 #include <string>
 #include <string_view>
-
-#include <Clove/Definitions.hpp>
 
 #define CLOVE_DECLARE_LOG_CATEGORY(categoryName)                 \
     struct LOG_CATEGORY_##categoryName {                         \
@@ -20,8 +19,8 @@ namespace spdlog {
 
 namespace clove {
     enum class LogLevel {
-        Trace,    /**< Extra info which is usually uneccessary. */
-        Debug,    /**< Anything which could help with debugging. */
+        Trace,    /**< Printed to the log file only. */
+        Debug,    /**< Lowest log level that will be printed to console. */
         Info,     /**< Useful information to present to the user. */
         Warning,  /**< When something happened that might cause an error. */
         Error,    /**< Something has gone wrong but is recoverable. */
@@ -43,7 +42,7 @@ namespace clove {
         static inline Logger &get();
 
         template<typename... Args>
-        void log(std::string_view category, LogLevel level, std::string_view msg, Args &&... args);
+        void log(std::string_view category, LogLevel level, std::string_view msg, Args &&...args);
 
         void addSink(std::shared_ptr<spdlog::sinks::sink> sink);
 
@@ -55,12 +54,12 @@ namespace clove {
 #define CLOVE_LOG(category, level, ...) ::clove::Logger::get().log(category::name, level, __VA_ARGS__);
 
 #if CLOVE_ENABLE_ASSERTIONS
-    #define CLOVE_ASSERT(x, ...)                                                                                          \
-        {                                                                                                                 \
-            if(!(x)) {                                                                                                    \
+    #define CLOVE_ASSERT(x, ...)                                                                                  \
+        {                                                                                                         \
+            if(!(x)) {                                                                                            \
                 CLOVE_LOG(LOG_CATEGORY_CLOVE, ::clove::LogLevel::Critical, "Assertion Failed: {0}", __VA_ARGS__); \
-                CLOVE_DEBUG_BREAK;                                                                                        \
-            }                                                                                                             \
+                CLOVE_DEBUG_BREAK;                                                                                \
+            }                                                                                                     \
         }
 #else
     #define CLOVE_ASSERT(x, ...) (x)

--- a/clove/components/utilities/log/source/Log.cpp
+++ b/clove/components/utilities/log/source/Log.cpp
@@ -4,22 +4,17 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
+#include <vector>
 
 namespace clove {
     Logger::Logger() {
-        auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        auto fileSink    = std::make_shared<spdlog::sinks::basic_file_sink_mt>("CLOVE_LOG.txt", true);
+        auto consoleSink{ std::make_shared<spdlog::sinks::stdout_color_sink_mt>() };
+        auto fileSink{ std::make_shared<spdlog::sinks::basic_file_sink_mt>("CLOVE_LOG.txt", true) };
 
         consoleSink->set_pattern("%^[%T] %v%$");
         fileSink->set_pattern("[%D %T][%l] %v");
 
-#if CLOVE_LOG_LEVEL == 2
-        consoleSink->set_level(spdlog::level::trace);
-#elif CLOVE_LOG_LEVEL == 1
         consoleSink->set_level(spdlog::level::debug);
-#else
-        consoleSink->set_level(spdlog::level::info);
-#endif
         fileSink->set_level(spdlog::level::trace);
 
         std::vector<spdlog::sink_ptr> sinks{ consoleSink, fileSink };


### PR DESCRIPTION
## Summary
Closes #353

## Changes
- Console log sink now only handles Debug logs and up. Trace logs are now only for the file sink.