### PR TITLE
Removed the CLOVE_DEBUG macro

### DIFF
--- a/clove/components/core/audio/CMakeLists.txt
+++ b/clove/components/core/audio/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/Clove/Audio)
 
+#CMake
+option(CLOVE_ENABLE_AHA_VALIDATION "Sets the CLOVE_AHA_VALIDATION macro to 1. Allowing for extra code to run to validate usage of the CloveAudio library." OFF)
+
 #Library
 add_library(
     CloveAudio STATIC
@@ -33,7 +36,6 @@ target_include_directories(
     
 	PUBLIC
 		include
-
 )
 
 #Libraries
@@ -48,4 +50,12 @@ target_link_libraries(
 
     PRIVATE
         CONAN_PKG::openal
+)
+
+#Preprocessor
+target_compile_definitions(
+	CloveAudio
+
+	PUBLIC
+		CLOVE_AHA_VALIDATION=$<BOOL:${CLOVE_ENABLE_AHA_VALIDATION}>
 )

--- a/clove/components/core/audio/include/Clove/Audio/OpenAL/OpenAlSource.hpp
+++ b/clove/components/core/audio/include/Clove/Audio/OpenAL/OpenAlSource.hpp
@@ -28,7 +28,7 @@ namespace clove {
         void setBuffer(std::unique_ptr<AhaBuffer> buffer) override;
 
         void queueBuffers(std::vector<std::unique_ptr<AhaBuffer>> buffers) override;
-        std::vector<std::unique_ptr<AhaBuffer>> unQueueBuffers(uint32_t const numToUnqueue) override;
+        std::vector<std::unique_ptr<AhaBuffer>> unQueueBuffers(uint32_t numToUnqueue) override;
 
         void setPitch(float pitch) override;
         void setLooping(bool isLooping) override;

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -32,7 +32,7 @@ namespace clove {
         alCall(alSourcei(source, AL_BUFFER, alBuffer->getBufferId()));
 
         bufferQueue.clear();
-        bufferQueue.push_back( std::move(buffer) );
+        bufferQueue.push_back(std::move(buffer));
     }
 
     void OpenAlSource::queueBuffers(std::vector<std::unique_ptr<AhaBuffer>> buffers) {
@@ -54,11 +54,16 @@ namespace clove {
         }
     }
 
-    std::vector<std::unique_ptr<AhaBuffer>> OpenAlSource::unQueueBuffers(uint32_t const numToUnqueue) {
-#if CLOVE_DEBUG
-        const uint32_t maxAbleToUnQueue{ getNumBuffersProcessed() };
-        CLOVE_ASSERT(numToUnqueue <= maxAbleToUnQueue, "{0}, Can't unqueue {1} buffers. Only {2} buffers have been processed", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
+    std::vector<std::unique_ptr<AhaBuffer>> OpenAlSource::unQueueBuffers(uint32_t numToUnqueue) {
+        {
+            const uint32_t maxAbleToUnQueue{ getNumBuffersProcessed() };
+#if CLOVE_AHA_VALIDATION
+            CLOVE_ASSERT(numToUnqueue <= maxAbleToUnQueue, "{0}: Can't unqueue {1} buffers. Only {2} buffers have been processed", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
+#else
+            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "{0}: {1} buffers attempted to unqueue but only {2} are avaiable. Clamping to {2}", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
+            numToUnqueue = maxAbleToUnQueue;
 #endif
+        }
 
         auto *buffers{ new ALuint[numToUnqueue] };
         alCall(alSourceUnqueueBuffers(source, numToUnqueue, buffers));

--- a/clove/components/core/graphics/CMakeLists.txt
+++ b/clove/components/core/graphics/CMakeLists.txt
@@ -2,6 +2,10 @@ set(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 set(INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/Clove/Graphics)
 set(ASSETS ${CMAKE_CURRENT_SOURCE_DIR}/assets)
 
+#CMake
+option(CLOVE_ENABLE_GHA_VALIDATION "Sets the CLOVE_GHA_VALIDATION macro to 1. Allowing for extra code to run to validate usage of the CloveGraphics library." OFF)
+option(CLOVE_COMPILE_DEBUG_SHADERS "Compiles shaders in debug mode, disabling optimisations." OFF)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	find_package(Vulkan REQUIRED)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
@@ -258,6 +262,15 @@ target_compile_options(
 	#MacOS
 	PRIVATE
 		$<$<PLATFORM_ID:Darwin>:-fobjc-arc>
+)
+
+#Preprocessor
+target_compile_definitions(
+	CloveGraphics
+
+	PUBLIC
+		CLOVE_GHA_VALIDATION=$<BOOL:${CLOVE_ENABLE_GHA_VALIDATION}>
+		CLOVE_COMPILE_DEBUG_SHADERS=$<BOOL:${CLOVE_COMPILE_DEBUG_SHADERS}>
 )
 
 #Don't compile files not supported on certain platforms

--- a/clove/components/core/graphics/source/ShaderCompiler.cpp
+++ b/clove/components/core/graphics/source/ShaderCompiler.cpp
@@ -105,10 +105,10 @@ namespace clove::ShaderCompiler {
 
             shaderc::CompileOptions options{};
             options.SetIncluder(std::move(includer));
-#if !CLOVE_DEBUG
-            options.SetOptimizationLevel(shaderc_optimization_level_performance);
-#else
+#if CLOVE_COMPILE_DEBUG_SHADERS
             options.SetOptimizationLevel(shaderc_optimization_level_zero);
+#else
+            options.SetOptimizationLevel(shaderc_optimization_level_performance);
 #endif
 
             shaderc::Compiler compiler{};

--- a/clove/components/core/graphics/source/Vulkan/DevicePointer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/DevicePointer.cpp
@@ -89,7 +89,7 @@ namespace clove {
 
     void DevicePointer::release() {
         if(counter != nullptr && --(*counter) == 0) {
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
             destroyDebugUtilsMessengerEXT(instance, debugMessenger, nullptr);
 #endif
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -221,12 +221,12 @@ namespace clove {
 #elif CLOVE_PLATFORM_LINUX
                 VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
 #endif
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
                 VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
 #endif
         };
 
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
         std::vector<char const *> const validationLayers{
             "VK_LAYER_KHRONOS_validation"
         };
@@ -249,7 +249,7 @@ namespace clove {
                 .apiVersion         = VK_API_VERSION_1_2,
             };
 
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
             VkDebugUtilsMessengerCreateInfoEXT debugMessengerCreateInfo{
                 .sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
                 .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
@@ -261,7 +261,7 @@ namespace clove {
 
             VkInstanceCreateInfo createInfo {
                 .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
                 .pNext                = &debugMessengerCreateInfo,//Setting the pNext allows us to debug the creation and destruction of the instance (as normaly we need an instance pointer to enable debugging)
                     .pApplicationInfo = &appInfo,
                 .enabledLayerCount    = static_cast<uint32_t>(std::size(validationLayers)),
@@ -281,7 +281,7 @@ namespace clove {
                 return;
             }
 
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
             if(createDebugUtilsMessengerEXT(instance, &debugMessengerCreateInfo, nullptr, &debugMessenger) != VK_SUCCESS) {
                 CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create vk debug message callback");
                 return;
@@ -400,7 +400,7 @@ namespace clove {
                 .queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size()),
                 .pQueueCreateInfos    = queueCreateInfos.data(),
 
-#if CLOVE_DEBUG
+#if CLOVE_GHA_VALIDATION
                 //We don't need to do this as device specific validation layers are no more. But seeing as it's the same data we can reuse them to support older versions
                     .enabledLayerCount = static_cast<uint32_t>(validationLayers.size()),
                 .ppEnabledLayerNames   = validationLayers.data(),

--- a/clove/components/utilities/definitions/CMakeLists.txt
+++ b/clove/components/utilities/definitions/CMakeLists.txt
@@ -1,6 +1,3 @@
-#CMake
-option(CLOVE_ENABLE_DEBUG_DEFINITION "Sets the CLOVE_DEBUG macro to 1. Allowing for various debug functionality / information to be enabled" OFF)
-
 #Library
 add_library(
 	CloveDefinitions INTERFACE
@@ -23,7 +20,4 @@ target_compile_definitions(
 		CLOVE_PLATFORM_WINDOWS=$<PLATFORM_ID:Windows>
 		CLOVE_PLATFORM_LINUX=$<PLATFORM_ID:Linux>
 		CLOVE_PLATFORM_MACOS=$<PLATFORM_ID:Darwin>
-
-		#Flags
-		CLOVE_DEBUG=$<BOOL:${CLOVE_ENABLE_DEBUG_DEFINITION}>
 )

--- a/clove/components/utilities/definitions/README.md
+++ b/clove/components/utilities/definitions/README.md
@@ -1,2 +1,2 @@
 The Definitions library of the Root layer contains all the definitions the Garlic engine uses.
-These definitions can be platform or configuration definitions (GARLIC_WINDOWS or CLOVE_DEBUG) or can be more complex ones (CLOVE_ASSERT)
+These definitions can be platform or configuration definitions (CLOVE_WINDOWS) or can be more complex ones (CLOVE_ASSERT)


### PR DESCRIPTION
## Summary
All usages have been replaced with more granulated macros (like GHA validation). This is to allow for more control over what is included within a build

## Changes
- Removed CLOVE_DEBUG macro
