### PR TITLE
Added an 'Open Project' flow to Bulb

### DIFF
--- a/bulb/CMakeLists.txt
+++ b/bulb/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(
 		${SOURCE}/Views/EntityInfo.xaml.cs
 		${SOURCE}/Views/MainWindow.xaml
 		${SOURCE}/Views/MainWindow.xaml.cs
+		${SOURCE}/Views/ProjectSelector.xaml
+		${SOURCE}/Views/ProjectSelector.xaml.cs
 		${SOURCE}/Views/Vector3Box.xaml
 		${SOURCE}/Views/Vector3Box.xaml.cs
 		${SOURCE}/Views/Viewport.xaml
@@ -105,6 +107,9 @@ csharp_set_xaml_cs_properties(
 
 	${SOURCE}/Views/MainWindow.xaml
     ${SOURCE}/Views/MainWindow.xaml.cs
+
+	${SOURCE}/Views/ProjectSelector.xaml
+	${SOURCE}/Views/ProjectSelector.xaml.cs
 	
 	${SOURCE}/Views/Vector3Box.xaml
 	${SOURCE}/Views/Vector3Box.xaml.cs

--- a/bulb/components/membrane/include/Membrane/Application.hpp
+++ b/bulb/components/membrane/include/Membrane/Application.hpp
@@ -20,6 +20,7 @@ namespace membrane {
      * @brief Translates a Clove session into C++/CLI
      */
 public ref class Application {
+        //VARIABLES
     private:
         clove::Application *app;
         clove::GraphicsImageRenderTarget *renderTarget;
@@ -31,10 +32,16 @@ public ref class Application {
         int width;
         int height;
 
+        //FUNCTIONS
     public:
         Application(int const width, int const height);
         ~Application();
         !Application();
+
+        bool hasDefaultProject();
+        
+        void openProject(System::String ^projectPath);
+        void openDefaultProject();
 
         bool isRunning();
         void tick();
@@ -46,6 +53,8 @@ public ref class Application {
         System::String ^resolveVfsPath(System::String ^path);
 
     private:
+        void openProjectInternal(std::filesystem::path const projectPath);
+
         void setEditorMode(Editor_Stop ^message);
         void setRuntimeMode(Editor_Play ^message);
     };

--- a/bulb/components/membrane/include/Membrane/EditorLayer.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorLayer.hpp
@@ -41,11 +41,12 @@ namespace membrane {
         void onUpdate(clove::DeltaTime const deltaTime) override;
         void onDetach() override;
 
-    private:
+    //private:
         //TODO: Save and load scene to custom file
         void saveScene();
         void loadScene();
 
+    private:
         clove::Entity createEntity(std::string_view name = "New Entity");
         void deleteEntity(clove::Entity entity);
 

--- a/bulb/components/membrane/include/Membrane/Scene.hpp
+++ b/bulb/components/membrane/include/Membrane/Scene.hpp
@@ -11,13 +11,12 @@ namespace membrane {
     private:
         clove::EntityManager *manager{ nullptr };
 
-        std::filesystem::path sceneFile;
         std::vector<clove::Entity> knownEntities{};
 
         //FUNCTIONS
     public:
         Scene() = delete;
-        Scene(clove::EntityManager *manager, std::filesystem::path saveData);
+        Scene(clove::EntityManager *manager);
 
         Scene(Scene const &other)     = delete;
         Scene(Scene &&other) noexcept = delete;
@@ -27,8 +26,8 @@ namespace membrane {
 
         ~Scene();
 
-        void save();
-        void load();
+        void save(std::filesystem::path const savePath);
+        void load(std::filesystem::path const loadPath);
 
         inline clove::Entity createEntity();
         inline void deleteEntity(clove::Entity);

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -95,6 +95,7 @@ namespace membrane {
     }
 
     void Application::shutdown() {
+        (*editorLayer)->saveScene();
         app->shutdown();
     }
 
@@ -144,6 +145,8 @@ namespace membrane {
     }
 
     void Application::setRuntimeMode(Editor_Play ^message) {
+        (*editorLayer)->saveScene();
+
         app->popLayer(*editorLayer);
         app->pushLayer(*runtimeLayer);
     }

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -17,8 +17,13 @@
 #include <Clove/Log/Log.hpp>
 #include <Clove/Rendering/GraphicsImageRenderTarget.hpp>
 #include <msclr/marshal_cppstd.h>
+#include <filesystem>
+#include <Clove/Serialisation/Node.hpp>
+#include <Clove/Serialisation/Yaml.hpp>
 
 namespace membrane {
+    static std::filesystem::path const cachedProjectsPath{ "projects.yaml" };
+
     Application::Application(int const width, int const height)
         : width{ width }
         , height{ height } {
@@ -38,23 +43,12 @@ namespace membrane {
         app          = pair.first.release();
         renderTarget = pair.second;
 
-        //Mount editor paths
-        auto *vfs{ app->getFileSystem() };
-        vfs->mount(std::filesystem::current_path() / "data", ".");//TODO: Root path of editor is unlikely to be it's working directory
-
-        std::filesystem::create_directories(vfs->resolve("."));
-
-        //Push layers
+        //Create layers
         editorLayer  = new std::shared_ptr<EditorLayer>();
         *editorLayer = std::make_shared<EditorLayer>();
 
         runtimeLayer  = new std::shared_ptr<RuntimeLayer>();
         *runtimeLayer = std::make_shared<RuntimeLayer>();
-
-        app->pushLayer(*editorLayer);
-
-        MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_Stop ^>(this, &Application::setEditorMode));
-        MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_Play ^>(this, &Application::setRuntimeMode));
     }
 
     Application::~Application() {
@@ -65,6 +59,25 @@ namespace membrane {
         delete app;
         delete editorLayer;
         delete runtimeLayer;
+    }
+
+    bool Application::hasDefaultProject() {
+        return std::filesystem::exists(cachedProjectsPath);
+    }
+
+    void Application::openProject(System::String ^projectPath) {
+        std::string projectPathString{ msclr::interop::marshal_as<std::string>(projectPath) };
+
+        openProjectInternal(projectPathString);
+    }
+
+    void Application::openDefaultProject() {
+        CLOVE_ASSERT(std::filesystem::exists(cachedProjectsPath));
+
+        auto loadResult{ clove::loadYaml(cachedProjectsPath) };
+        clove::serialiser::Node rootNode{ loadResult.getValue() };
+
+        openProjectInternal(rootNode["projects"]["default"].as<std::string>());
     }
 
     bool Application::isRunning() {
@@ -100,7 +113,32 @@ namespace membrane {
         return gcnew System::String(app->getFileSystem()->resolve(unManagedPath).c_str());
     }
 
-    void Application::setEditorMode(Editor_Stop ^message) {
+    void Application::openProjectInternal(std::filesystem::path const projectPath) {
+        clove::serialiser::Node rootNode{};
+        rootNode["projects"]["version"] = 1;
+        rootNode["projects"]["default"] = projectPath.string();
+
+        std::ofstream fileStream{ cachedProjectsPath, std::ios::out | std::ios::trunc };
+        fileStream << clove::emittYaml(rootNode);
+
+        //Currently project files are empty but they are used to mark a project's location
+        std::filesystem::path const rootProjectPath{ projectPath.parent_path() };
+
+        //Mount editor paths
+        auto *vfs{ app->getFileSystem() };
+        vfs->mount(rootProjectPath / "content", ".");
+
+        std::filesystem::create_directories(vfs->resolve("."));
+
+        //Push layers
+        app->pushLayer(*editorLayer);
+
+        //Bind to editor messages
+        MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_Stop ^>(this, &Application::setEditorMode));
+        MessageHandler::bindToMessage(gcnew MessageSentHandler<Editor_Play ^>(this, &Application::setRuntimeMode));
+    }
+
+    void Application::setEditorMode(Editor_Stop ^ message) {
         app->popLayer(*runtimeLayer);
         app->pushLayer(*editorLayer);
     }

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -62,7 +62,14 @@ namespace membrane {
     }
 
     bool Application::hasDefaultProject() {
-        return std::filesystem::exists(cachedProjectsPath);
+        if(std::filesystem::exists(cachedProjectsPath)) {
+            auto loadResult{ clove::loadYaml(cachedProjectsPath) };
+            clove::serialiser::Node rootNode{ loadResult.getValue() };
+
+            return std::filesystem::exists(rootNode["projects"]["default"].as<std::string>());
+        }
+
+        return false;
     }
 
     void Application::openProject(System::String ^projectPath) {

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -115,7 +115,7 @@ namespace membrane {
 namespace membrane {
     EditorLayer::EditorLayer()
         : clove::Layer{ "Editor Layer" }
-        , currentScene{ clove::Application::get().getEntityManager(), "scene.yaml" } {
+        , currentScene{ clove::Application::get().getEntityManager() } {
         proxy = gcnew EditorLayerMessageProxy(this);
     }
 
@@ -233,11 +233,11 @@ namespace membrane {
     }
 
     void EditorLayer::saveScene() {
-        currentScene.save();
+        currentScene.save(clove::Application::get().getFileSystem()->resolve("./scene.clvscene"));
     }
 
     void EditorLayer::loadScene() {
-        currentScene.load();
+        currentScene.load(clove::Application::get().getFileSystem()->resolve("./scene.clvscene"));
 
         Engine_OnSceneLoaded ^ loadMessage { gcnew Engine_OnSceneLoaded };
         loadMessage->entities = gcnew System::Collections::Generic::List<Entity ^>{};

--- a/bulb/components/membrane/source/EditorLayer.cpp
+++ b/bulb/components/membrane/source/EditorLayer.cpp
@@ -228,7 +228,7 @@ namespace membrane {
     }
 
     void EditorLayer::onDetach() {
-        saveScene();
+        //saveScene();
         currentScene.destroyAllEntities();
     }
 

--- a/bulb/components/membrane/source/RuntimeLayer.cpp
+++ b/bulb/components/membrane/source/RuntimeLayer.cpp
@@ -13,7 +13,7 @@
 namespace membrane {
     RuntimeLayer::RuntimeLayer()
         : clove::Layer{ "Runtime Layer" }
-        , currentScene{ clove::Application::get().getEntityManager(), "scene.yaml" } {
+        , currentScene{ clove::Application::get().getEntityManager() } {
     }
 
     void RuntimeLayer::onAttach() {
@@ -22,7 +22,7 @@ namespace membrane {
         //push the physics layer from the application
         app.pushLayer(app.getPhysicsLayer());
 
-        currentScene.load();
+        currentScene.load(clove::Application::get().getFileSystem()->resolve("./scene.clvscene"));
     }
 
     void RuntimeLayer::onUpdate(clove::DeltaTime const deltaTime) {

--- a/bulb/components/membrane/source/Scene.cpp
+++ b/bulb/components/membrane/source/Scene.cpp
@@ -29,14 +29,13 @@ namespace membrane {
         }
     }
 
-    Scene::Scene(EntityManager *manager, std::filesystem::path saveData)
-        : manager{ manager }
-        , sceneFile{ std::move(saveData) } {
+    Scene::Scene(EntityManager *manager)
+        : manager{ manager } {
     }
 
     Scene::~Scene() = default;
 
-    void Scene::save() {
+    void Scene::save(std::filesystem::path const savePath) {
         serialiser::Node rootNode{};
         for(Entity entity : knownEntities) {
             serialiser::Node entityNode{};
@@ -52,11 +51,11 @@ namespace membrane {
             rootNode["entities"].pushBack(entityNode);
         }
 
-        std::ofstream fileStream{ sceneFile, std::ios::out | std::ios::trunc };
+        std::ofstream fileStream{ savePath, std::ios::out | std::ios::trunc };
         fileStream << emittYaml(rootNode);
     }
 
-    void Scene::load() {
+    void Scene::load(std::filesystem::path const loadPath) {
         //Only destroy known entities to avoid deleting meta ones (such as the camera)
         for(Entity entity : knownEntities) {
             manager->destroy(entity);
@@ -64,11 +63,11 @@ namespace membrane {
         knownEntities.clear();
 
         //File won't exist if we haven't saved anything yet
-        if(!std::filesystem::exists(sceneFile)) {
+        if(!std::filesystem::exists(loadPath)) {
             return;
         }
 
-        auto loadResult{ loadYaml(sceneFile) };
+        auto loadResult{ loadYaml(loadPath) };
         serialiser::Node rootNode{ loadResult.getValue() };
 
         for(auto const &entityNode : rootNode["entities"]) {

--- a/bulb/source/EditorApp.xaml.cs
+++ b/bulb/source/EditorApp.xaml.cs
@@ -10,6 +10,8 @@ namespace Bulb {
     /// </summary>
     public partial class EditorApp : Application {
         private MainWindow editorWindow;
+        private ProjectSelector projectSelector;
+
         private EditorSessionViewModel sessionViewModel;
 
         private Membrane.Application engineApp;
@@ -22,6 +24,36 @@ namespace Bulb {
         private void EditorStartup(object sender, StartupEventArgs e) {
             //Initialise the engine
             engineApp = new Membrane.Application((int)size.Width, (int)size.Height);
+
+            //Check if the engine can load a previously used project or if we need to create a new one
+            if (!engineApp.hasDefaultProject()) {
+                OpenProjectSelector();
+            } else {
+                engineApp.openDefaultProject();
+                StartEditorSession();
+            }
+        }
+
+        private void OpenProjectSelector() {
+            //Change to explicit shut down to stop when project selector closes
+            ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+            projectSelector = new ProjectSelector();
+            projectSelector.OnProjectSelected += OnProjectSelected;
+
+            projectSelector.Show();
+        }
+
+        private void OnProjectSelected(string filePath) {
+            engineApp.openProject(filePath);
+
+            projectSelector.Close();
+
+            StartEditorSession();
+        }
+
+        private void StartEditorSession() {
+            ShutdownMode = ShutdownMode.OnLastWindowClose;
 
             //Set up the engine session
             sessionViewModel = new EditorSessionViewModel(".");

--- a/bulb/source/Views/MainWindow.xaml
+++ b/bulb/source/Views/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:Bulb"
 		xmlns:membrane="clr-namespace:membrane;assembly=BulbMembrane"
         mc:Ignorable="d"
-        Title="Garlic - 0.4.0" Width="1280" Height="720"
+        Title="Clove - 0.4.0" Width="1280" Height="720"
 		Style="{StaticResource PrimaryWindowStyle}"
 		MouseMove="Window_MouseMove"
 		KeyUp="Window_KeyUp">

--- a/bulb/source/Views/ProjectSelector.xaml
+++ b/bulb/source/Views/ProjectSelector.xaml
@@ -6,18 +6,11 @@
         xmlns:local="clr-namespace:Bulb"
         mc:Ignorable="d"
 		WindowStyle="None"
-		WindowState="Normal"
+		ResizeMode="NoResize"
 		WindowStartupLocation="CenterScreen"
 		Width="800"
-		Height="600"
+		Height="200"
 		Background="{StaticResource Background1}">
-	<WindowChrome.WindowChrome>
-		<WindowChrome CaptionHeight="1"
-					  CornerRadius="0"
-					  ResizeBorderThickness="4"
-					  GlassFrameThickness="0"/>
-	</WindowChrome.WindowChrome>
-
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto"/>
@@ -32,9 +25,11 @@
 		<StackPanel Grid.Row="1"
 					VerticalAlignment="Center">
 			<Button Content="New Project"
-					Margin="0 0 0 5"/>
+					Margin="0 0 0 5"
+					Click="NewProjectButtonClick"/>
 			<Button Content="Open Project"
-					Margin="0 5 0 0"/>
+					Margin="0 5 0 0"
+					Click="OpenProjectButtonClick"/>
 		</StackPanel>
 	</Grid>
 </Window>

--- a/bulb/source/Views/ProjectSelector.xaml
+++ b/bulb/source/Views/ProjectSelector.xaml
@@ -1,0 +1,40 @@
+<Window x:Class="Bulb.ProjectSelector"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Bulb"
+        mc:Ignorable="d"
+		WindowStyle="None"
+		WindowState="Normal"
+		WindowStartupLocation="CenterScreen"
+		Width="800"
+		Height="600"
+		Background="{StaticResource Background1}">
+	<WindowChrome.WindowChrome>
+		<WindowChrome CaptionHeight="1"
+					  CornerRadius="0"
+					  ResizeBorderThickness="4"
+					  GlassFrameThickness="0"/>
+	</WindowChrome.WindowChrome>
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="1*"/>
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Row="0"
+				   Text="Clove Engine - 0.4.0"
+				   HorizontalAlignment="Center"
+				   FontSize="40"/>
+
+		<StackPanel Grid.Row="1"
+					VerticalAlignment="Center">
+			<Button Content="New Project"
+					Margin="0 0 0 5"/>
+			<Button Content="Open Project"
+					Margin="0 5 0 0"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/bulb/source/Views/ProjectSelector.xaml.cs
+++ b/bulb/source/Views/ProjectSelector.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace Bulb {
+    public partial class ProjectSelector : Window {
+
+    }
+}

--- a/bulb/source/Views/ProjectSelector.xaml.cs
+++ b/bulb/source/Views/ProjectSelector.xaml.cs
@@ -1,7 +1,31 @@
+using Microsoft.Win32;
+using System.IO;
 using System.Windows;
 
 namespace Bulb {
     public partial class ProjectSelector : Window {
+        public delegate void ProjectSelectedDelegate(string path);
+        public ProjectSelectedDelegate OnProjectSelected;
 
+        public ProjectSelector() {
+            InitializeComponent();
+        }
+
+        private void NewProjectButtonClick(object sender, RoutedEventArgs e) {
+            var dialog = new SaveFileDialog();
+            dialog.Filter = "Clove project files (*.clvproj)|*.clvproj";
+            if (dialog.ShowDialog() == true) {
+                File.Create(dialog.FileName);
+                OnProjectSelected?.Invoke(dialog.FileName);
+            }
+        }
+
+        private void OpenProjectButtonClick(object sender, RoutedEventArgs e) {
+            var dialog = new OpenFileDialog();
+            dialog.Filter = "Clove project files (*.clvproj)|*.clvproj";
+            if (dialog.ShowDialog() == true) {
+                OnProjectSelected?.Invoke(dialog.FileName);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
If it's the first time running Bulb then the user can either create or open a clvproj.

## Changes
- Added the `ProjectSelector` view.
- When running Bulb for the first time a project selected dialog will appear.
- `Scene` now takes in a bespoke file every time it saves and loads.
- Added a work around for saving the scene from `Applications`'s destructor. (see #373).