### PR TITLE
Improved the user experience of the input fields of entity values

### DIFF
--- a/bulb/CMakeLists.txt
+++ b/bulb/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
 	    ${SOURCE}/EditorApp.xaml
         ${SOURCE}/EditorApp.xaml.cs
 
+		${SOURCE}/EditorPropertyHelper.cs
 		${SOURCE}/SizePercentageConverter.cs
 
 	    ${SOURCE}/AssemblyInfo.cs

--- a/bulb/components/membrane/include/Membrane/EditorTypes.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorTypes.hpp
@@ -27,6 +27,13 @@ namespace membrane {
         }
     };
 
+    public ref class TransformComponentInitData{
+    public:
+        Vector3 position;
+        Vector3 rotation;
+        Vector3 scale;
+    };
+
     public ref class StaticModelComponentInitData{
     public:
         System::String ^meshPath;

--- a/bulb/source/EditorPropertyHelper.cs
+++ b/bulb/source/EditorPropertyHelper.cs
@@ -1,0 +1,5 @@
+namespace Bulb{
+    class EditorPropertyHelper {
+        public static float InputStringToFloat(string value) => float.TryParse(value, out float result) ? result : 0;
+    }
+}

--- a/bulb/source/ViewModels/Components/CollisionShapeComponentViewModel.cs
+++ b/bulb/source/ViewModels/Components/CollisionShapeComponentViewModel.cs
@@ -19,37 +19,78 @@ namespace Bulb {
             }
         }
 
+        #region Sphere Properties
         public string Radius {
-            get => radius.ToString();
+            get => radius;
             set {
-                float.TryParse(value, out var number);
-                OnSphereShapeChanged?.Invoke(number);
-            }
-        }
-        private float radius = 1.0f;
+                radius = value;
+                radiusNum = EditorPropertyHelper.InputStringToFloat(radius);
 
+                OnSphereShapeChanged?.Invoke(radiusNum);
+                OnPropertyChanged(nameof(Radius));
+            }
+        }
+        private string radius;
+        private float radiusNum;
+
+        public Visibility RadiusVisibility {
+            get => radiusVisibility;
+            private set {
+                radiusVisibility = value;
+                OnPropertyChanged(nameof(RadiusVisibility));
+            }
+        }
+        private Visibility radiusVisibility = Visibility.Visible;
+        #endregion
+
+        #region Cube Properties
         public string HalfExtentsX {
-            get => halfExtents.x.ToString();
+            get => halfExtentsX;
             set {
-                float.TryParse(value, out var number);
-                OnCubeShapeChanged?.Invoke(new Membrane.Vector3(number, halfExtents.y, halfExtents.z));
+                halfExtentsX = value;
+                halfExtents.x = EditorPropertyHelper.InputStringToFloat(halfExtentsX);
+
+                OnCubeShapeChanged?.Invoke(halfExtents);
+                OnPropertyChanged(nameof(HalfExtentsX));
             }
         }
+        private string halfExtentsX;
+
         public string HalfExtentsY {
-            get => halfExtents.y.ToString();
+            get => halfExtentsY;
             set {
-                float.TryParse(value, out var number);
-                OnCubeShapeChanged?.Invoke(new Membrane.Vector3(halfExtents.x, number, halfExtents.z));
+                halfExtentsY = value;
+                halfExtents.y = EditorPropertyHelper.InputStringToFloat(halfExtentsY);
+
+                OnCubeShapeChanged?.Invoke(halfExtents);
+                OnPropertyChanged(nameof(halfExtentsY));
             }
         }
+        private string halfExtentsY;
+
         public string HalfExtentsZ {
-            get => halfExtents.z.ToString();
+            get => halfExtentsZ;
             set {
-                float.TryParse(value, out var number);
-                OnCubeShapeChanged?.Invoke(new Membrane.Vector3(halfExtents.x, halfExtents.y, number));
+                halfExtentsZ = value;
+                halfExtents.x = EditorPropertyHelper.InputStringToFloat(halfExtentsZ);
+
+                OnCubeShapeChanged?.Invoke(halfExtents);
+                OnPropertyChanged(nameof(halfExtentsZ));
             }
         }
+        private string halfExtentsZ;
+
         private Membrane.Vector3 halfExtents = new Membrane.Vector3(0.5f, 0.5f, 0.5f);
+
+        public Visibility HalfExtentsVisibility {
+            get => halfExtentsVisibility;
+            private set {
+                halfExtentsVisibility = value;
+                OnPropertyChanged(nameof(HalfExtentsVisibility));
+            }
+        }
+        private Visibility halfExtentsVisibility = Visibility.Visible;
+        #endregion
 
         public Membrane.ShapeType CurrentShapeType {
             get => currentShapeType;
@@ -61,24 +102,6 @@ namespace Bulb {
         private Membrane.ShapeType currentShapeType;
 
         public ObservableCollection<ShapeTypeViewModel> AvailableShapes { get; } = new ObservableCollection<ShapeTypeViewModel>();
-
-        public Visibility RadiusVisibility {
-            get => radiusVisibility;
-            private set {
-                radiusVisibility = value;
-                OnPropertyChanged(nameof(RadiusVisibility));
-            }
-        }
-        private Visibility radiusVisibility = Visibility.Visible;
-
-        public Visibility HalfExtentsVisibility {
-            get { return halfExtentsVisibility; }
-            private set {
-                halfExtentsVisibility = value;
-                OnPropertyChanged(nameof(HalfExtentsVisibility));
-            }
-        }
-        private Visibility halfExtentsVisibility = Visibility.Visible;
 
         public delegate void CollisionShapeSphereChanged(float radius);
         public delegate void CollisionShapeCubeChanged(Membrane.Vector3 halfExtents);
@@ -100,15 +123,32 @@ namespace Bulb {
         }
 
         public void UpdateSphereShape(float radius) {
-            this.radius = radius;
+            radiusNum = radius;
+            this.radius = radiusNum.ToString();
             OnPropertyChanged(nameof(Radius));
         }
 
         public void UpdateCubeShape(Membrane.Vector3 halfExtents) {
             this.halfExtents = halfExtents;
+
+            halfExtentsX = halfExtents.x.ToString();
+            halfExtentsY = halfExtents.y.ToString();
+            halfExtentsZ = halfExtents.z.ToString();
+
             OnPropertyChanged(nameof(HalfExtentsX));
             OnPropertyChanged(nameof(HalfExtentsY));
             OnPropertyChanged(nameof(HalfExtentsZ));
+        }
+
+        public void RefreshValues() {
+            switch (CurrentShapeType) {
+                case Membrane.ShapeType.Sphere:
+                    UpdateSphereShape(radiusNum);
+                    break;
+                case Membrane.ShapeType.Cube:
+                    UpdateCubeShape(halfExtents);
+                    break;
+            }
         }
 
         private void OnShapeTypeChanged(Membrane.ShapeType newType, bool invokeDelegates = true) {
@@ -119,7 +159,7 @@ namespace Bulb {
                     RadiusVisibility = Visibility.Visible;
                     HalfExtentsVisibility = Visibility.Collapsed;
                     if (invokeDelegates) {
-                        OnSphereShapeChanged?.Invoke(radius);
+                        OnSphereShapeChanged?.Invoke(radiusNum);
                     }
                     break;
                 case Membrane.ShapeType.Cube:

--- a/bulb/source/ViewModels/Components/RigidBodyComponentViewModel.cs
+++ b/bulb/source/ViewModels/Components/RigidBodyComponentViewModel.cs
@@ -3,26 +3,34 @@ using Membrane = membrane;
 namespace Bulb {
     public class RigidBodyComponentViewModel : ComponentViewModel {
         public string Mass {
-            get => mass.ToString();
+            get => mass;
             set {
-                float.TryParse(value, out float number);
-                OnRigidBodyChanged?.Invoke(number);
+                mass = value;
+                massNum = EditorPropertyHelper.InputStringToFloat(mass);
+
+                OnRigidBodyChanged?.Invoke(massNum);
+                OnPropertyChanged(nameof(Mass));
             }
         }
-        private float mass;
+        private string mass;
+        private float massNum;
 
         public delegate void RigdBodyChangedHandler(float mass);
         public RigdBodyChangedHandler OnRigidBodyChanged;
 
         public RigidBodyComponentViewModel(Membrane.RigidBodyComponentInitData initData) 
             : base($"{Membrane.ComponentType.RigidBody}", Membrane.ComponentType.RigidBody) {
-            mass = initData.mass;
+            Update(initData.mass);
         }
 
         public void Update(float mass) {
-            this.mass = mass;
-
+            massNum = mass;
+            this.mass = massNum.ToString();
             OnPropertyChanged(nameof(Mass));
+        }
+
+        public void RefreshValues() {
+            Update(massNum);
         }
     }
 }

--- a/bulb/source/ViewModels/Components/TransformComponentViewModel.cs
+++ b/bulb/source/ViewModels/Components/TransformComponentViewModel.cs
@@ -1,134 +1,167 @@
 using Membrane = membrane;
 
-namespace Bulb
-{
+namespace Bulb {
     /// <summary>
     /// Viewmodel representing a Transform Component
     /// </summary>
-    public class TransformComponentViewModel : ComponentViewModel
-    {
-        //Position
-        public string PositionXValue
-        {
-            get { return position.x.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(new Membrane.Vector3(number, position.y, position.z), rotation, scale);
-            }
-        }
-        public string PositionYValue
-        {
-            get { return position.y.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(new Membrane.Vector3(position.x, number, position.z), rotation, scale);
-            }
-        }
-        public string PositionZValue
-        {
-            get { return position.z.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(new Membrane.Vector3(position.x, position.y, number), rotation, scale);
-            }
-        }
-
-        //Rotation
-        public string RotationXValue
-        {
-            get { return rotation.x.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(position, new Membrane.Vector3(number, rotation.y, rotation.z), scale);
-            }
-        }
-        public string RotationYValue
-        {
-            get { return rotation.y.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(position, new Membrane.Vector3(rotation.x, number, rotation.z), scale);
-            }
-        }
-        public string RotationZValue
-        {
-            get { return rotation.z.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(position, new Membrane.Vector3(rotation.x, rotation.y, number), scale);
-            }
-        }
-
-        //Scale
-        public string ScaleXValue
-        {
-            get { return scale.x.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(position, rotation, new Membrane.Vector3(number, scale.y, scale.z));
-            }
-        }
-        public string ScaleYValue
-        {
-            get { return scale.y.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(position, rotation, new Membrane.Vector3(scale.x, number, scale.z));
-            }
-        }
-        public string ScaleZValue
-        {
-            get { return scale.z.ToString(); }
-            set
-            {
-                float number;
-                float.TryParse(value, out number);
-                OnTransformChanged?.Invoke(position, rotation, new Membrane.Vector3(scale.x, scale.y, number));
-            }
-        }
-
+    public class TransformComponentViewModel : ComponentViewModel {
+        #region Position
         private Membrane.Vector3 position = new Membrane.Vector3();
+
+        public string PositionXValue {
+            get => positionXValue;
+            set {
+                positionXValue = value;
+                position.x = EditorPropertyHelper.InputStringToFloat(positionXValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(PositionXValue));
+            }
+        }
+        private string positionXValue;
+
+        public string PositionYValue {
+            get => positionYValue;
+            set {
+                positionYValue = value;
+                position.y = EditorPropertyHelper.InputStringToFloat(positionYValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(PositionYValue));
+            }
+        }
+        private string positionYValue;
+
+        public string PositionZValue {
+            get => positionZValue;
+            set {
+                positionZValue = value;
+                position.z = EditorPropertyHelper.InputStringToFloat(positionZValue);
+                
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(PositionZValue));
+            }
+        }
+        private string positionZValue;
+        #endregion
+
+        #region Rotation
         private Membrane.Vector3 rotation = new Membrane.Vector3();
+
+        public string RotationXValue {
+            get => rotationXValue;
+            set {
+                rotationXValue = value;
+                rotation.x = EditorPropertyHelper.InputStringToFloat(rotationXValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(RotationXValue));
+            }
+        }
+        private string rotationXValue;
+
+        public string RotationYValue {
+            get => rotationYValue;
+            set {
+                rotationYValue = value;
+                rotation.y = EditorPropertyHelper.InputStringToFloat(rotationYValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(RotationYValue));
+            }
+        }
+        private string rotationYValue;
+
+        public string RotationZValue {
+            get => rotationZValue;
+            set {
+                rotationZValue = value;
+                rotation.z = EditorPropertyHelper.InputStringToFloat(rotationZValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(RotationZValue));
+            }
+        }
+        private string rotationZValue;
+        #endregion
+
+        #region Scale
         private Membrane.Vector3 scale = new Membrane.Vector3(1, 1, 1);
+
+        public string ScaleXValue {
+            get => scaleXValue;
+            set {
+                scaleXValue = value;
+                scale.x = EditorPropertyHelper.InputStringToFloat(scaleXValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(ScaleXValue));
+            }
+        }
+        private string scaleXValue;
+
+        public string ScaleYValue {
+            get => scaleYValue;
+            set {
+                scaleYValue = value;
+                scale.y = EditorPropertyHelper.InputStringToFloat(scaleYValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(ScaleYValue));
+            }
+        }
+        private string scaleYValue;
+
+        public string ScaleZValue {
+            get => scaleZValue;
+            set {
+                scaleZValue = value;
+                scale.z = EditorPropertyHelper.InputStringToFloat(scaleZValue);
+
+                BroadcastTransformChange();
+                OnPropertyChanged(nameof(ScaleZValue));
+            }
+        }
+        private string scaleZValue;
+        #endregion
 
         public delegate void TransformChangedHandler(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale);
         public TransformChangedHandler OnTransformChanged;
 
-        public TransformComponentViewModel() 
-            : base($"{Membrane.ComponentType.Transform}", Membrane.ComponentType.Transform) { }
+        public TransformComponentViewModel(Membrane.TransformComponentInitData initData)
+            : base($"{Membrane.ComponentType.Transform}", Membrane.ComponentType.Transform) {
+            Update(initData.position, initData.rotation, initData.scale);
+        }
 
-        public void Update(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale){
-            this.position = position;
-            this.rotation = rotation;
-            this.scale = scale;
-
+        public void Update(Membrane.Vector3 position, Membrane.Vector3 rotation, Membrane.Vector3 scale) {
+            positionXValue = position.x.ToString();
+            positionYValue = position.y.ToString();
+            positionZValue = position.z.ToString();
             OnPropertyChanged(nameof(PositionXValue));
             OnPropertyChanged(nameof(PositionYValue));
             OnPropertyChanged(nameof(PositionZValue));
 
+            rotationXValue = rotation.x.ToString();
+            rotationYValue = rotation.y.ToString();
+            rotationZValue = rotation.z.ToString();
             OnPropertyChanged(nameof(RotationXValue));
             OnPropertyChanged(nameof(RotationYValue));
             OnPropertyChanged(nameof(RotationZValue));
 
+            scaleXValue = scale.x.ToString();
+            scaleYValue = scale.y.ToString();
+            scaleZValue = scale.z.ToString();
             OnPropertyChanged(nameof(ScaleXValue));
             OnPropertyChanged(nameof(ScaleYValue));
             OnPropertyChanged(nameof(ScaleZValue));
+        }
+
+        public void RefreshValues() {
+            Update(position, rotation, scale);
+        }
+
+        private void BroadcastTransformChange() {
+            OnTransformChanged?.Invoke(position, rotation, scale);
         }
     }
 }

--- a/bulb/source/ViewModels/EntityViewModel.cs
+++ b/bulb/source/ViewModels/EntityViewModel.cs
@@ -94,7 +94,7 @@ namespace Bulb {
 
             switch (type) {
                 case Membrane.ComponentType.Transform: {
-                    var transformComp = new TransformComponentViewModel {
+                    var transformComp = new TransformComponentViewModel(initData as Membrane.TransformComponentInitData) {
                         OnTransformChanged = UpdateTransform
                     };
 

--- a/bulb/source/Views/EntityInfo.xaml
+++ b/bulb/source/Views/EntityInfo.xaml
@@ -65,21 +65,24 @@
 												  CenterFieldText="Y"
 												  CenterFieldValue="{Binding PositionYValue, Mode=TwoWay}"
 												  RightFieldText="Z"
-												  RightFieldValue="{Binding PositionZValue, Mode=TwoWay}"/>
+												  RightFieldValue="{Binding PositionZValue, Mode=TwoWay}"
+												  LostFocus="TransformPropertyLostFocus"/>
 								<local:Vector3Box Label="Rotation"
 												  LeftFieldText="X"
 												  LeftFieldValue="{Binding RotationXValue, Mode=TwoWay}"
 												  CenterFieldText="Y"
 												  CenterFieldValue="{Binding RotationYValue, Mode=TwoWay}"
 												  RightFieldText="Z"
-												  RightFieldValue="{Binding RotationZValue, Mode=TwoWay}"/>
+												  RightFieldValue="{Binding RotationZValue, Mode=TwoWay}"
+												  LostFocus="TransformPropertyLostFocus"/>
 								<local:Vector3Box Label="Scale"
 												  LeftFieldText="X"
 												  LeftFieldValue="{Binding ScaleXValue, Mode=TwoWay}"
 												  CenterFieldText="Y"
 												  CenterFieldValue="{Binding ScaleYValue, Mode=TwoWay}"
 												  RightFieldText="Z"
-												  RightFieldValue="{Binding ScaleZValue, Mode=TwoWay}"/>
+												  RightFieldValue="{Binding ScaleZValue, Mode=TwoWay}"
+												  LostFocus="TransformPropertyLostFocus"/>
 							</StackPanel>
 						</StackPanel>
 					</DataTemplate>
@@ -111,7 +114,8 @@
 								<TextBlock Grid.Column="0"
 										   Text="Mass"/>
 								<TextBox Grid.Column="1"
-										 Text="{Binding Mass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+										 Text="{Binding Mass, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+										 LostFocus="RigidBodyPropertyLostFocus"/>
 							</Grid>
 						</StackPanel>
 					</DataTemplate>
@@ -150,7 +154,8 @@
 							<StackPanel Orientation="Horizontal"
 										Visibility="{Binding RadiusVisibility}">
 								<TextBlock Text="Radius"/>
-								<TextBox Text="{Binding Radius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+								<TextBox Text="{Binding Radius, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+										 LostFocus="CollisionShapePropertyLostFocus"/>
 							</StackPanel>
 							<local:Vector3Box Visibility="{Binding HalfExtentsVisibility}"
 											  Label="Half Extents"
@@ -159,7 +164,8 @@
 											  CenterFieldText="Y"
 											  CenterFieldValue="{Binding HalfExtentsY, Mode=TwoWay}"
 											  RightFieldText="Z"
-											  RightFieldValue="{Binding HalfExtentsZ, Mode=TwoWay}"/>
+											  RightFieldValue="{Binding HalfExtentsZ, Mode=TwoWay}"
+											  LostFocus="CollisionShapePropertyLostFocus"/>
 						</StackPanel>
 					</DataTemplate>
 

--- a/bulb/source/Views/EntityInfo.xaml.cs
+++ b/bulb/source/Views/EntityInfo.xaml.cs
@@ -31,5 +31,26 @@ namespace Bulb {
                 e.Handled = true;
             }
         }
+
+        private void TransformPropertyLostFocus(object sender, RoutedEventArgs e) {
+            var element = sender as FrameworkElement;
+            var viewmodel = element.DataContext as TransformComponentViewModel;
+
+            viewmodel.RefreshValues();
+        }
+
+        private void RigidBodyPropertyLostFocus(object sender, RoutedEventArgs e) {
+            var element = sender as FrameworkElement;
+            var viewmodel = element.DataContext as RigidBodyComponentViewModel;
+
+            viewmodel.RefreshValues();
+        }
+
+        private void CollisionShapePropertyLostFocus(object sender, RoutedEventArgs e) {
+            var element = sender as FrameworkElement;
+            var viewmodel = element.DataContext as CollisionShapeComponentViewModel;
+
+            viewmodel.RefreshValues();
+        }
     }
 }


### PR DESCRIPTION
## Summary
Inputs into fields are no longer bounced back. Really this should only happen if the data we receive from the editor is wrong somehow and we don't want to lose sync. Otherwise the engine should just accept that data and do nothing else

Closes #366

## Changes
- Improved the user experience of the input fields of entity values