### PR TITLE
Refactored InputEvent to be an alias for a variant

### DIFF
--- a/bulb/components/membrane/source/EditorSubSystem.cpp
+++ b/bulb/components/membrane/source/EditorSubSystem.cpp
@@ -172,15 +172,13 @@ namespace membrane {
     }
 
     clove::InputResponse EditorSubSystem::onInputEvent(clove::InputEvent const &inputEvent) {
-        if(inputEvent.eventType == clove::InputEvent::Type::Mouse) {
-            auto event{ std::get<clove::Mouse::Event>(inputEvent.event) };
-
-            if(event.getButton() == clove::MouseButton::Right) {
-                if(event.getType() == clove::Mouse::Event::Type::Pressed) {
+        if(auto const *const mouseEvent{ std::get_if<clove::Mouse::Event>(&inputEvent) }) {
+            if(mouseEvent->getButton() == clove::MouseButton::Right) {
+                if(mouseEvent->getType() == clove::Mouse::Event::Type::Pressed) {
                     //Make sure prev + pos gets updated when the event happens.
                     //This fixes situations where the mouse will be up, move and then go down
-                    mousePos     = event.getPos();
-                    prevMousePos = event.getPos();
+                    mousePos     = mouseEvent->getPos();
+                    prevMousePos = mouseEvent->getPos();
 
                     moveMouse = true;
                     return clove::InputResponse::Consumed;
@@ -190,8 +188,8 @@ namespace membrane {
                 }
             }
 
-            if(event.getType() == clove::Mouse::Event::Type::Move && moveMouse) {
-                mousePos = event.getPos();
+            if(mouseEvent->getType() == clove::Mouse::Event::Type::Move && moveMouse) {
+                mousePos = mouseEvent->getPos();
                 return clove::InputResponse::Consumed;
             }
         }

--- a/clove/include/Clove/InputEvent.hpp
+++ b/clove/include/Clove/InputEvent.hpp
@@ -5,13 +5,5 @@
 #include <variant>
 
 namespace clove {
-    struct InputEvent {
-        enum class Type {
-            Keyboard,
-            Mouse
-        };
-
-        std::variant<Keyboard::Event, Mouse::Event> event;
-        Type eventType;
-    };
+    using InputEvent = std::variant<Keyboard::Event, Mouse::Event>;
 }

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -75,7 +75,7 @@ namespace clove {
         renderer->begin();
 
         while(auto keyEvent = surface->getKeyboard().getKeyEvent()) {
-            InputEvent const event{ *keyEvent, InputEvent::Type::Keyboard };
+            InputEvent const event{ *keyEvent };
             for(auto &&[key, group] : subSystems) {
                 for(auto &subSystem : group) {
                     if(subSystem->onInputEvent(event) == InputResponse::Consumed) {
@@ -85,7 +85,7 @@ namespace clove {
             }
         }
         while(auto mouseEvent = surface->getMouse().getEvent()) {
-            InputEvent const event{ *mouseEvent, InputEvent::Type::Mouse };
+            InputEvent const event{ *mouseEvent };
             for(auto &&[key, group] : subSystems) {
                 for(auto &subSystem : group) {
                     if(subSystem->onInputEvent(event) == InputResponse::Consumed) {

--- a/clove/source/UI/UIFrame.cpp
+++ b/clove/source/UI/UIFrame.cpp
@@ -9,28 +9,20 @@ namespace clove {
     }
 
     InputResponse UIFrame::propagateInput(InputEvent const &inputEvent) {
-        switch(inputEvent.eventType) {
-            case InputEvent::Type::Keyboard:
-                //TODO: Needs to check if the elemet has focus
-                break;
+        if(auto const *const mouseEvent{ std::get_if<Mouse::Event>(&inputEvent) }){
+            for(auto &element : inputElements) {
+                ElementBounds const bounds{element->getBounds()};
+                auto const pos{mouseEvent->getPos()};
 
-            case InputEvent::Type::Mouse: {
-                auto const &mouseEvent = std::get<Mouse::Event>(inputEvent.event);
-                for(auto &element : inputElements) {
-                    ElementBounds const bounds{element->getBounds()};
-                    auto const pos{mouseEvent.getPos()};
-
-                    if(pos.x >= bounds.start.x && pos.x <= bounds.end.x &&
-                       pos.y >= bounds.start.y && pos.y <= bounds.end.y) {
-                        if(element->onMouseEvent(mouseEvent) == InputResponse::Consumed) {
-                            return InputResponse::Consumed;
-                        }
+                if(pos.x >= bounds.start.x && pos.x <= bounds.end.x &&
+                   pos.y >= bounds.start.y && pos.y <= bounds.end.y) {
+                    if(element->onMouseEvent(*mouseEvent) == InputResponse::Consumed) {
+                        return InputResponse::Consumed;
                     }
                 }
-            } break;
-            default:
-                break;
+            }
         }
+        //TODO: Keyboard event (requires focus)
 
         return InputResponse::Ignored;
     }


### PR DESCRIPTION
## Summary
Because the even itself is a variant the enum is not required as there are many ways to check and retrieve values from a variant

Closes #299 
