### PR TITLE
Refactored the GHA Queue API slightly

### DIFF
--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
@@ -29,8 +29,8 @@ namespace clove {
 
         virtual CommandQueueDescriptor const &getDescriptor() const = 0;
 
-        virtual std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() = 0;
-        virtual void freeCommandBuffer(GhaComputeCommandBuffer &buffer)          = 0;
+        virtual std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer()         = 0;
+        virtual void freeCommandBuffer(std::unique_ptr<GhaComputeCommandBuffer> &buffer) = 0;
 
         /**
          * @brief Submit command buffers to be processed.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputeQueue.hpp
@@ -37,8 +37,9 @@ namespace clove {
          * @details All buffers in a single submission will start in order but will likely finish out of order.
          * Batch them together like this if they can run at the same time. Each call to this submit function
          * will need to wait on previous submissions.
-         * @param signalFence An optional fence that will be signaled when all submissions are complete.
+         * @param submission
+         * @param signalFence An optional fence that will be signaled when the submission is complete.
          */
-        virtual void submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence *signalFence) = 0;
+        virtual void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) = 0;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
@@ -13,7 +13,7 @@ namespace clove {
 
     struct GraphicsSubmitInfo {
         std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
-        std::vector<GhaGraphicsCommandBuffer *> commandBuffers;             /**< The command buffers to execute */
+        std::vector<GhaGraphicsCommandBuffer *> commandBuffers;                     /**< The command buffers to execute */
         std::vector<GhaSemaphore const *> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
     };
 }
@@ -29,8 +29,8 @@ namespace clove {
 
         virtual CommandQueueDescriptor const &getDescriptor() const = 0;
 
-        virtual std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() = 0;
-        virtual void freeCommandBuffer(GhaGraphicsCommandBuffer &buffer)          = 0;
+        virtual std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer()         = 0;
+        virtual void freeCommandBuffer(std::unique_ptr<GhaGraphicsCommandBuffer> &buffer) = 0;
 
         /**
          * @brief Submit command buffers to be processed.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsQueue.hpp
@@ -37,8 +37,9 @@ namespace clove {
          * @details All buffers in a single submission will start in order but will likely finish out of order.
          * Batch them together like this if they can run at the same time. Each call to this submit function
          * will need to wait on previous submissions.
-         * @param signalFence An optional fence that will be signaled when all submissions are complete.
+         * @param submission
+         * @param signalFence An optional fence that will be signaled when the submission is complete.
          */
-        virtual void submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) = 0;
+        virtual void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) = 0;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
@@ -11,9 +11,9 @@ namespace clove {
     class GhaSemaphore;
 
     struct TransferSubmitInfo {
-        std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores;   /**< What semaphores to wait on at what stage */
-        std::vector<GhaTransferCommandBuffer *> commandBuffers;                       /**< The command buffers to execute */
-        std::vector<GhaSemaphore const *> signalSemaphores;                           /**< The semaphores that will be signaled when completed */
+        std::vector<std::pair<GhaSemaphore const *, PipelineStage>> waitSemaphores; /**< What semaphores to wait on at what stage */
+        std::vector<GhaTransferCommandBuffer *> commandBuffers;                     /**< The command buffers to execute */
+        std::vector<GhaSemaphore const *> signalSemaphores;                         /**< The semaphores that will be signaled when completed */
     };
 }
 
@@ -28,8 +28,8 @@ namespace clove {
 
         virtual CommandQueueDescriptor const &getDescriptor() const = 0;
 
-        virtual std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() = 0;
-        virtual void freeCommandBuffer(GhaTransferCommandBuffer &buffer)          = 0;
+        virtual std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer()         = 0;
+        virtual void freeCommandBuffer(std::unique_ptr<GhaTransferCommandBuffer> &buffer) = 0;
 
         /**
          * @brief Submit command buffers to be processed.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferQueue.hpp
@@ -36,8 +36,9 @@ namespace clove {
          * @details All buffers in a single submission will start in order but will likely finish out of order.
          * Batch them together like this if they can run at the same time. Each call to this submit function
          * will need to wait on previous submissions.
-         * @param signalFence An optional fence that will be signaled when all submissions are complete.
+         * @param submission
+         * @param signalFence An optional fence that will be signaled when the submission is complete.
          */
-        virtual void submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) = 0;
+        virtual void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) = 0;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeQueue.hpp
@@ -32,6 +32,6 @@ namespace clove {
         std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() override;
         void freeCommandBuffer(GhaComputeCommandBuffer &buffer) override;
 
-        void submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeQueue.hpp
@@ -30,7 +30,7 @@ namespace clove {
         CommandQueueDescriptor const &getDescriptor() const override;
 
         std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() override;
-        void freeCommandBuffer(GhaComputeCommandBuffer &buffer) override;
+        void freeCommandBuffer(std::unique_ptr<GhaComputeCommandBuffer> &buffer) override;
 
         void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsQueue.hpp
@@ -31,7 +31,7 @@ namespace clove {
         CommandQueueDescriptor const &getDescriptor() const override;
 
         std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() override;
-        void freeCommandBuffer(GhaGraphicsCommandBuffer &buffer) override;
+        void freeCommandBuffer(std::unique_ptr<GhaGraphicsCommandBuffer> &buffer) override;
 
         void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsQueue.hpp
@@ -33,6 +33,6 @@ namespace clove {
         std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() override;
         void freeCommandBuffer(GhaGraphicsCommandBuffer &buffer) override;
 
-        void submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferQueue.hpp
@@ -32,6 +32,6 @@ namespace clove {
         std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() override;
         void freeCommandBuffer(GhaTransferCommandBuffer &buffer) override;
 
-        void submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferQueue.hpp
@@ -30,7 +30,7 @@ namespace clove {
         CommandQueueDescriptor const &getDescriptor() const override;
 
         std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() override;
-        void freeCommandBuffer(GhaTransferCommandBuffer &buffer) override;
+        void freeCommandBuffer(std::unique_ptr<GhaTransferCommandBuffer> &buffer) override;
 
         void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.hpp
@@ -13,7 +13,7 @@ namespace clove {
 
         std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() override;
 
-        void submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 
     template<typename BaseQueueType>
@@ -24,7 +24,7 @@ namespace clove {
 
         std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() override;
 
-        void submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 
     template<typename BaseQueueType>
@@ -35,7 +35,7 @@ namespace clove {
 
         std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() override;
 
-        void submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.inl
@@ -9,24 +9,20 @@ namespace clove {
         }
 
         template<typename SubmissionType>
-        void validateBuffersUsage(std::vector<SubmissionType> const &submissions) {
-            for(auto const &submitInfo : submissions) {
-                for(auto &commandBuffer : submitInfo.commandBuffers) {
-                    auto *buffer{ dynamic_cast<ValidationCommandBuffer *>(commandBuffer) };
-                    if(buffer->getCommandBufferUsage() == CommandBufferUsage::OneTimeSubmit && buffer->bufferHasBeenUsed()){
-                        CLOVE_ASSERT(false, "GraphicsCommandBuffer recorded with CommandBufferUsage::OneTimeSubmit has already been used. Only buffers recorded with CommandBufferUsage::Default can submitted multiples times after being recorded once.");
-                        break;
-                    }
+        void validateBuffersUsage(SubmissionType const &submission) {
+            for(auto &commandBuffer : submission.commandBuffers) {
+                auto *buffer{ dynamic_cast<ValidationCommandBuffer *>(commandBuffer) };
+                if(buffer->getCommandBufferUsage() == CommandBufferUsage::OneTimeSubmit && buffer->bufferHasBeenUsed()) {
+                    CLOVE_ASSERT(false, "GraphicsCommandBuffer recorded with CommandBufferUsage::OneTimeSubmit has already been used. Only buffers recorded with CommandBufferUsage::Default can submitted multiples times after being recorded once.");
+                    break;
                 }
             }
         }
 
         template<typename SubmissionType>
-        void markBuffersAsUsed(std::vector<SubmissionType> const &submissions) {
-            for(auto const &submitInfo : submissions) {
-                for(auto &commandBuffer : submitInfo.commandBuffers) {
-                    dynamic_cast<ValidationCommandBuffer *>(commandBuffer)->markAsUsed();
-                }
+        void markBuffersAsUsed(SubmissionType const &submission) {
+            for(auto &commandBuffer : submission.commandBuffers) {
+                dynamic_cast<ValidationCommandBuffer *>(commandBuffer)->markAsUsed();
             }
         }
     }
@@ -42,12 +38,12 @@ namespace clove {
     }
 
     template<typename BaseQueueType>
-    void ValidationGraphicsQueue<BaseQueueType>::submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) {
-        detail::validateBuffersUsage(submissions);
+    void ValidationGraphicsQueue<BaseQueueType>::submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) {
+        detail::validateBuffersUsage(submission);
 
-        BaseQueueType::submit(submissions, signalFence);
+        BaseQueueType::submit(submission, signalFence);
 
-        detail::markBuffersAsUsed(submissions);
+        detail::markBuffersAsUsed(submission);
     }
 
     //Compute
@@ -61,12 +57,12 @@ namespace clove {
     }
 
     template<typename BaseQueueType>
-    void ValidationComputeQueue<BaseQueueType>::submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence *signalFence) {
-        detail::validateBuffersUsage(submissions);
+    void ValidationComputeQueue<BaseQueueType>::submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) {
+        detail::validateBuffersUsage(submission);
 
-        BaseQueueType::submit(submissions, signalFence);
+        BaseQueueType::submit(submission, signalFence);
 
-        detail::markBuffersAsUsed(submissions);
+        detail::markBuffersAsUsed(submission);
     }
 
     //Transfer
@@ -80,11 +76,11 @@ namespace clove {
     }
 
     template<typename BaseQueueType>
-    void ValidationTransferQueue<BaseQueueType>::submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) {
-        detail::validateBuffersUsage(submissions);
-        
-        BaseQueueType::submit(submissions, signalFence);
+    void ValidationTransferQueue<BaseQueueType>::submit(TransferSubmitInfo const &submission, GhaFence *signalFence) {
+        detail::validateBuffersUsage(submission);
 
-        detail::markBuffersAsUsed(submissions);
+        BaseQueueType::submit(submission, signalFence);
+
+        detail::markBuffersAsUsed(submission);
     }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeQueue.hpp
@@ -36,6 +36,6 @@ namespace clove {
         std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() override;
         void freeCommandBuffer(GhaComputeCommandBuffer &buffer) override;
 
-        void submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeQueue.hpp
@@ -34,7 +34,7 @@ namespace clove {
         CommandQueueDescriptor const &getDescriptor() const override;
 
         std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() override;
-        void freeCommandBuffer(GhaComputeCommandBuffer &buffer) override;
+        void freeCommandBuffer(std::unique_ptr<GhaComputeCommandBuffer> &buffer) override;
 
         void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsQueue.hpp
@@ -36,6 +36,6 @@ namespace clove {
         std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() override;
         void freeCommandBuffer(GhaGraphicsCommandBuffer &buffer) override;
 
-        void submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsQueue.hpp
@@ -34,7 +34,7 @@ namespace clove {
         CommandQueueDescriptor const &getDescriptor() const override;
 
         std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() override;
-        void freeCommandBuffer(GhaGraphicsCommandBuffer &buffer) override;
+        void freeCommandBuffer(std::unique_ptr<GhaGraphicsCommandBuffer> &buffer) override;
 
         void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferQueue.hpp
@@ -34,7 +34,7 @@ namespace clove {
         CommandQueueDescriptor const &getDescriptor() const override;
 
         std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() override;
-        void freeCommandBuffer(GhaTransferCommandBuffer &buffer) override;
+        void freeCommandBuffer(std::unique_ptr<GhaTransferCommandBuffer> &buffer) override;
 
         void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferQueue.hpp
@@ -36,6 +36,6 @@ namespace clove {
         std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() override;
         void freeCommandBuffer(GhaTransferCommandBuffer &buffer) override;
 
-        void submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) override;
+        void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 }

--- a/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
@@ -31,58 +31,52 @@ namespace clove {
         //no op
     }
     
-    void MetalComputeQueue::submit(std::vector<ComputeSubmitInfo> const &submissions, GhaFence *signalFence) {
+    void MetalComputeQueue::submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) {
         @autoreleasepool{
-            for(size_t i{ 0 }; i < submissions.size(); ++i) {
-                auto const &submission{ submissions[i] };
-                bool const isLastSubmission{ i == submissions.size() - 1 };
+            for(auto *commandBuffer : submission.commandBuffers) {
+                bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
                 
-                for(auto *commandBuffer : submission.commandBuffers) {
-                    bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
-                    
-                    auto *metalCommandBuffer{ polyCast<MetalComputeCommandBuffer>(commandBuffer) };
-                    if(metalCommandBuffer == nullptr) {
-                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                auto *metalCommandBuffer{ polyCast<MetalComputeCommandBuffer>(commandBuffer) };
+                if(metalCommandBuffer == nullptr) {
+                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    continue;
+                }
+                
+                id<MTLCommandBuffer> executionBuffer{ [commandQueue commandBuffer] };
+                id<MTLComputeCommandEncoder> encoder{ [executionBuffer computeCommandEncoder] };
+                
+                //Inject the wait semaphore into each buffer
+                for (auto const &semaphore : submission.waitSemaphores) {
+                    auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
+                    if(metalSemaphore == nullptr) {
+                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
                     }
-
-                    id<MTLCommandBuffer> executionBuffer{ [commandQueue commandBuffer] };
-                    id<MTLComputeCommandEncoder> encoder{ [executionBuffer computeCommandEncoder] };
                     
-                    //Inject the wait semaphore into each buffer
-                    for (auto const &semaphore : submission.waitSemaphores) {
-                        auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
-                        if(metalSemaphore == nullptr) {
-                            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
-                            continue;
-                        }
-                        
-                        [encoder waitForFence:metalSemaphore->getFence()];
-                    }
-                    
-                    //Excute all recorded commands for the encoder
-                    for(auto const &command : metalCommandBuffer->getCommands()) {
-                        command(encoder);
-                    }
-                    
-                    //For the last buffer add all semaphore signalling
-                    if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
-                        for(auto const &semaphore : submission.signalSemaphores) {
-                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
-                        }
-                    }
-                    
-                    //For the last submission signal the fence
-                    if(isLastSubmission && signalFence != nullptr) {
-                        __block auto *fence{ polyCast<MetalFence>(signalFence) };
-                        [executionBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-                            fence->signal();
-                        }];
-                    }
-                    
-                    [encoder endEncoding];
-                    [executionBuffer commit];
+                    [encoder waitForFence:metalSemaphore->getFence()];
                 }
+                
+                //Excute all recorded commands for the encoder
+                for(auto const &command : metalCommandBuffer->getCommands()) {
+                    command(encoder);
+                }
+                
+                //For the last buffer add all semaphore signalling
+                if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
+                    for(auto const &semaphore : submission.signalSemaphores) {
+                        [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
+                    }
+                }
+                
+                if(signalFence != nullptr) {
+                    __block auto *fence{ polyCast<MetalFence>(signalFence) };
+                    [executionBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+                        fence->signal();
+                    }];
+                }
+                
+                [encoder endEncoding];
+                [executionBuffer commit];
             }
         }
     }

--- a/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
@@ -27,8 +27,8 @@ namespace clove {
         return createGhaObject<MetalComputeCommandBuffer>();
     }
     
-    void MetalComputeQueue::freeCommandBuffer(GhaComputeCommandBuffer &buffer) {
-        //no op
+    void MetalComputeQueue::freeCommandBuffer(std::unique_ptr<GhaComputeCommandBuffer> &buffer) {
+        buffer.reset();
     }
     
     void MetalComputeQueue::submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) {

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
@@ -20,17 +20,17 @@ namespace clove {
     MetalGraphicsQueue& MetalGraphicsQueue::operator=(MetalGraphicsQueue &&other) noexcept = default;
     
     MetalGraphicsQueue::~MetalGraphicsQueue() = default;
-    
-    std::unique_ptr<GhaGraphicsCommandBuffer> MetalGraphicsQueue::allocateCommandBuffer() {
-        return createGhaObject<MetalGraphicsCommandBuffer>();
-    }
 
     CommandQueueDescriptor const &MetalGraphicsQueue::getDescriptor() const {
         return descriptor;
     }
     
-    void MetalGraphicsQueue::freeCommandBuffer(GhaGraphicsCommandBuffer &buffer) {
-        //no op
+    std::unique_ptr<GhaGraphicsCommandBuffer> MetalGraphicsQueue::allocateCommandBuffer() {
+        return createGhaObject<MetalGraphicsCommandBuffer>();
+    }
+    
+    void MetalGraphicsQueue::freeCommandBuffer(std::unique_ptr<GhaGraphicsCommandBuffer> &buffer) {
+        buffer.reset();
     }
     
     void MetalGraphicsQueue::submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) {

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
@@ -33,66 +33,60 @@ namespace clove {
         //no op
     }
     
-    void MetalGraphicsQueue::submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) {
+    void MetalGraphicsQueue::submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) {
         @autoreleasepool{
-            for(size_t i{ 0 }; i < submissions.size(); ++i) {
-                auto const &submission{ submissions[i] };
-                bool const isLastSubmission{ i == submissions.size() - 1 };
+            for(auto *commandBuffer : submission.commandBuffers) {
+                bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
                 
-                for(auto *commandBuffer : submission.commandBuffers) {
-                    bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
-                    
-                    auto *metalCommandBuffer{ polyCast<MetalGraphicsCommandBuffer>(commandBuffer) };
-                    if(metalCommandBuffer == nullptr) {
-                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
-                        continue;
-                    }
-                   
-                    id<MTLCommandBuffer> executionBuffer{ [commandQueue commandBuffer] };
-                    
-                    for(auto const &pass : metalCommandBuffer->getEncodedRenderPasses()) {
-                        id<MTLRenderCommandEncoder> encoder{ pass.begin(executionBuffer) };
-                        
-                        //Inject the wait semaphore into each buffer
-                        for (auto const &semaphore : submission.waitSemaphores) {
-                            auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
-                            if(metalSemaphore == nullptr) {
-                                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
-                                continue;
-                            }
-                            
-                            MTLRenderStages const waitStage{ convertStage(semaphore.second) };
-                            
-                            [encoder waitForFence:metalSemaphore->getFence()
-                                     beforeStages:waitStage];
-                        }
-                        
-                        //Excute all recorded commands for the encoder
-                        for(auto const &command : pass.commands) {
-                            command(encoder);
-                        }
-                        
-                        //For the last buffer add all semaphore signalling
-                        if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
-                            for(auto const &semaphore : submission.signalSemaphores) {
-                                [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()
-                                         afterStages:MTLRenderStageFragment];
-                            }
-                        }
-                        
-                        [encoder endEncoding];
-                    }
-                    
-                    //For the last submission signal the fence
-                    if(isLastSubmission && signalFence != nullptr) {
-                        __block auto *fence{ polyCast<MetalFence>(signalFence) };
-                        [executionBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-                            fence->signal();
-                        }];
-                    }
-                    
-                    [executionBuffer commit];
+                auto *metalCommandBuffer{ polyCast<MetalGraphicsCommandBuffer>(commandBuffer) };
+                if(metalCommandBuffer == nullptr) {
+                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    continue;
                 }
+               
+                id<MTLCommandBuffer> executionBuffer{ [commandQueue commandBuffer] };
+                
+                for(auto const &pass : metalCommandBuffer->getEncodedRenderPasses()) {
+                    id<MTLRenderCommandEncoder> encoder{ pass.begin(executionBuffer) };
+                    
+                    //Inject the wait semaphore into each buffer
+                    for (auto const &semaphore : submission.waitSemaphores) {
+                        auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
+                        if(metalSemaphore == nullptr) {
+                            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                            continue;
+                        }
+                        
+                        MTLRenderStages const waitStage{ convertStage(semaphore.second) };
+                        
+                        [encoder waitForFence:metalSemaphore->getFence()
+                                 beforeStages:waitStage];
+                    }
+                    
+                    //Excute all recorded commands for the encoder
+                    for(auto const &command : pass.commands) {
+                        command(encoder);
+                    }
+                    
+                    //For the last buffer add all semaphore signalling
+                    if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
+                        for(auto const &semaphore : submission.signalSemaphores) {
+                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()
+                                     afterStages:MTLRenderStageFragment];
+                        }
+                    }
+                    
+                    [encoder endEncoding];
+                }
+                
+                if(signalFence != nullptr) {
+                    __block auto *fence{ polyCast<MetalFence>(signalFence) };
+                    [executionBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+                        fence->signal();
+                    }];
+                }
+                
+                [executionBuffer commit];
             }
         }
     }

--- a/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
@@ -28,8 +28,8 @@ namespace clove {
         return createGhaObject<MetalTransferCommandBuffer>();
     }
     
-    void MetalTransferQueue::freeCommandBuffer(GhaTransferCommandBuffer &buffer) {
-        //no op
+    void MetalTransferQueue::freeCommandBuffer(std::unique_ptr<GhaTransferCommandBuffer> &buffer) {
+        buffer.reset();
     }
     
     void MetalTransferQueue::submit(TransferSubmitInfo const &submission, GhaFence *signalFence) {

--- a/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
@@ -32,58 +32,52 @@ namespace clove {
         //no op
     }
     
-    void MetalTransferQueue::submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) {
+    void MetalTransferQueue::submit(TransferSubmitInfo const &submission, GhaFence *signalFence) {
         @autoreleasepool{
-            for(size_t i{ 0 }; i < submissions.size(); ++i) {
-                auto const &submission{ submissions[i] };
-                bool const isLastSubmission{ i == submissions.size() - 1 };
+            for(auto *commandBuffer : submission.commandBuffers) {
+                bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
                 
-                for(auto *commandBuffer : submission.commandBuffers) {
-                    bool const isLastCommandBuffer{ commandBuffer == submission.commandBuffers.back() };
-                    
-                    auto *metalCommandBuffer{ polyCast<MetalTransferCommandBuffer>(commandBuffer) };
-                    if(metalCommandBuffer == nullptr) {
-                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                auto *metalCommandBuffer{ polyCast<MetalTransferCommandBuffer>(commandBuffer) };
+                if(metalCommandBuffer == nullptr) {
+                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    continue;
+                }
+                
+                id<MTLCommandBuffer> executionBuffer{ [commandQueue commandBuffer] };
+                id<MTLBlitCommandEncoder> encoder{ [executionBuffer blitCommandEncoder] };
+                
+                //Inject the wait semaphore into each buffer
+                for (auto const &semaphore : submission.waitSemaphores) {
+                    auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
+                    if(metalSemaphore == nullptr) {
+                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
                     }
                     
-                    id<MTLCommandBuffer> executionBuffer{ [commandQueue commandBuffer] };
-                    id<MTLBlitCommandEncoder> encoder{ [executionBuffer blitCommandEncoder] };
-                    
-                    //Inject the wait semaphore into each buffer
-                    for (auto const &semaphore : submission.waitSemaphores) {
-                        auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
-                        if(metalSemaphore == nullptr) {
-                            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
-                            continue;
-                        }
-                        
-                        [encoder waitForFence:metalSemaphore->getFence()];
-                    }
-                    
-                    //Excute all recorded commands for the encoder
-                    for(auto const &command : metalCommandBuffer->getCommands()) {
-                        command(encoder);
-                    }
-                    
-                    //For the last buffer add all semaphore signalling
-                    if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
-                        for(auto const &semaphore : submission.signalSemaphores) {
-                            [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
-                        }
-                    }
-                    
-                    //For the last submission signal the fence
-                    if(isLastSubmission && signalFence != nullptr) {
-                        __block auto *fence{ polyCast<MetalFence>(signalFence) };
-                        [executionBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-                            fence->signal();
-                        }];
-                    }
-                    
-                    [encoder endEncoding];
-                    [executionBuffer commit];
+                    [encoder waitForFence:metalSemaphore->getFence()];
                 }
+                
+                //Excute all recorded commands for the encoder
+                for(auto const &command : metalCommandBuffer->getCommands()) {
+                    command(encoder);
+                }
+                
+                //For the last buffer add all semaphore signalling
+                if(isLastCommandBuffer && !submission.signalSemaphores.empty()) {
+                    for(auto const &semaphore : submission.signalSemaphores) {
+                        [encoder updateFence:polyCast<MetalSemaphore const>(semaphore)->getFence()];
+                    }
+                }
+                
+                if(signalFence != nullptr) {
+                    __block auto *fence{ polyCast<MetalFence>(signalFence) };
+                    [executionBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
+                        fence->signal();
+                    }];
+                }
+                
+                [encoder endEncoding];
+                [executionBuffer commit];
             }
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
@@ -49,9 +49,11 @@ namespace clove {
         return createGhaObject<VulkanComputeCommandBuffer>(commandBuffer, queueFamilyIndices);
     }
 
-    void VulkanComputeQueue::freeCommandBuffer(GhaComputeCommandBuffer &buffer) {
-        VkCommandBuffer const commandBuffer{ polyCast<VulkanComputeCommandBuffer>(&buffer)->getCommandBuffer() };
+    void VulkanComputeQueue::freeCommandBuffer(std::unique_ptr<GhaComputeCommandBuffer> &buffer) {
+        VkCommandBuffer const commandBuffer{ polyCast<VulkanComputeCommandBuffer>(buffer.get())->getCommandBuffer() };
         vkFreeCommandBuffers(device.get(), commandPool, 1, &commandBuffer);
+
+        buffer.reset();
     }
 
     void VulkanComputeQueue::submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) {

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
@@ -50,9 +50,11 @@ namespace clove {
         return createGhaObject<VulkanGraphicsCommandBuffer>(commandBuffer, queueFamilyIndices);
     }
 
-    void VulkanGraphicsQueue::freeCommandBuffer(GhaGraphicsCommandBuffer &buffer) {
-        VkCommandBuffer const vkbuffer{ polyCast<VulkanGraphicsCommandBuffer>(&buffer)->getCommandBuffer() };
+    void VulkanGraphicsQueue::freeCommandBuffer(std::unique_ptr<GhaGraphicsCommandBuffer> &buffer) {
+        VkCommandBuffer const vkbuffer{ polyCast<VulkanGraphicsCommandBuffer>(buffer.get())->getCommandBuffer() };
         vkFreeCommandBuffers(device.get(), commandPool, 1, &vkbuffer);
+
+        buffer.reset();
     }
 
     void VulkanGraphicsQueue::submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) {

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
@@ -55,56 +55,50 @@ namespace clove {
         vkFreeCommandBuffers(device.get(), commandPool, 1, &vkbuffer);
     }
 
-    void VulkanGraphicsQueue::submit(std::vector<GraphicsSubmitInfo> const &submissions, GhaFence *signalFence) {
-        size_t const submissioncount{ submissions.size() };
-        std::vector<VkSubmitInfo> vkSubmissions;
-        vkSubmissions.reserve(submissioncount);
+    void VulkanGraphicsQueue::submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) {
+        //Wait semaphores / stages
+        std::vector<VkSemaphore> waitSemaphores{};
+        std::vector<VkPipelineStageFlags> waitStages{};
+        size_t const waitSemaphoreCount{ submission.waitSemaphores.size() };
+        waitSemaphores.resize(waitSemaphoreCount);
+        waitStages.resize(waitSemaphoreCount);
 
-        std::vector<std::vector<VkSemaphore>> waitSemaphores(submissioncount);
-        std::vector<std::vector<VkPipelineStageFlags>> waitStages(submissioncount);
-        std::vector<std::vector<VkCommandBuffer>> commandBuffers(submissioncount);
-        std::vector<std::vector<VkSemaphore>> signalSemaphores(submissioncount);
-
-        for(size_t i{ 0 }; i < submissioncount; ++i) {
-            //Wait semaphores / stages
-            size_t const waitSemaphoreCount{ std::size(submissions[i].waitSemaphores) };
-            waitSemaphores[i].resize(waitSemaphoreCount);
-            waitStages[i].resize(waitSemaphoreCount);
-
-            for(size_t j = 0; j < waitSemaphoreCount; ++j) {
-                waitSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].waitSemaphores[j].first)->getSemaphore();
-                waitStages[i][j]     = convertStage(submissions[i].waitSemaphores[j].second);
-            }
-
-            //Command buffers
-            size_t const commandBufferCount{ std::size(submissions[i].commandBuffers) };
-            commandBuffers[i].resize(commandBufferCount);
-            for(size_t j = 0; j < commandBufferCount; ++j) {
-                commandBuffers[i][j] = polyCast<VulkanGraphicsCommandBuffer const>(submissions[i].commandBuffers[j])->getCommandBuffer();
-            }
-
-            //Signal semaphores
-            size_t const signalSemaphoreCount{ std::size(submissions[i].signalSemaphores) };
-            signalSemaphores[i].resize(signalSemaphoreCount);
-            for(size_t j = 0; j < signalSemaphoreCount; ++j) {
-                signalSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].signalSemaphores[j])->getSemaphore();
-            }
-
-            vkSubmissions.emplace_back(VkSubmitInfo{
-                .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-                .waitSemaphoreCount   = static_cast<uint32_t>(waitSemaphoreCount),
-                .pWaitSemaphores      = std::data(waitSemaphores[i]),
-                .pWaitDstStageMask    = std::data(waitStages[i]),
-                .commandBufferCount   = static_cast<uint32_t>(commandBufferCount),
-                .pCommandBuffers      = std::data(commandBuffers[i]),
-                .signalSemaphoreCount = static_cast<uint32_t>(signalSemaphoreCount),
-                .pSignalSemaphores    = std::data(signalSemaphores[i]),
-            });
+        for(size_t i{ 0 }; i < waitSemaphoreCount; ++i) {
+            waitSemaphores[i] = polyCast<VulkanSemaphore const>(submission.waitSemaphores[i].first)->getSemaphore();
+            waitStages[i]     = convertStage(submission.waitSemaphores[i].second);
         }
+
+        //Command buffers
+        std::vector<VkCommandBuffer> commandBuffers{};
+        size_t const commandBufferCount{ submission.commandBuffers.size() };
+        commandBuffers.resize(commandBufferCount);
+        for(size_t i{ 0 }; i < commandBufferCount; ++i) {
+            commandBuffers[i] = polyCast<VulkanGraphicsCommandBuffer const>(submission.commandBuffers[i])->getCommandBuffer();
+        }
+
+        //Signal semaphores
+        std::vector<VkSemaphore> signalSemaphores{};
+        size_t const signalSemaphoreCount{ submission.signalSemaphores.size() };
+        signalSemaphores.resize(signalSemaphoreCount);
+        for(size_t i{ 0 }; i < signalSemaphoreCount; ++i) {
+            signalSemaphores[i] = polyCast<VulkanSemaphore const>(submission.signalSemaphores[i])->getSemaphore();
+        }
+
+        VkSubmitInfo const submitInfo{
+            .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+            .waitSemaphoreCount   = static_cast<uint32_t>(waitSemaphoreCount),
+            .pWaitSemaphores      = waitSemaphores.data(),
+            .pWaitDstStageMask    = waitStages.data(),
+            .commandBufferCount   = static_cast<uint32_t>(commandBufferCount),
+            .pCommandBuffers      = commandBuffers.data(),
+            .signalSemaphoreCount = static_cast<uint32_t>(signalSemaphoreCount),
+            .pSignalSemaphores    = signalSemaphores.data(),
+        };
 
         VkFence const vkFence{ signalFence != nullptr ? polyCast<VulkanFence const>(signalFence)->getFence() : VK_NULL_HANDLE };
 
-        if(vkQueueSubmit(queue, std::size(vkSubmissions), std::data(vkSubmissions), vkFence) != VK_SUCCESS) {
+        uint32_t constexpr submitCount{ 1 };
+        if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
             CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to submit graphics command buffer(s)");
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
@@ -58,57 +58,51 @@ namespace clove {
         vkFreeCommandBuffers(device.get(), commandPool, 1, &vkbuffer);
     }
 
-    void VulkanTransferQueue::submit(std::vector<TransferSubmitInfo> const &submissions, GhaFence *signalFence) {
-        auto const submissioncount{ std::size(submissions) };
-        std::vector<VkSubmitInfo> vkSubmissions;
-        vkSubmissions.reserve(submissioncount);
+    void VulkanTransferQueue::submit(TransferSubmitInfo const &submission, GhaFence *signalFence) {
+        //Wait semaphores / stages
+        std::vector<VkSemaphore> waitSemaphores{};
+        std::vector<VkPipelineStageFlags> waitStages{};
+        size_t const waitSemaphoreCount{ submission.waitSemaphores.size() };
+        waitSemaphores.resize(waitSemaphoreCount);
+        waitStages.resize(waitSemaphoreCount);
 
-        std::vector<std::vector<VkSemaphore>> waitSemaphores(submissioncount);
-        std::vector<std::vector<VkPipelineStageFlags>> waitStages(submissioncount);
-        std::vector<std::vector<VkCommandBuffer>> commandBuffers(submissioncount);
-        std::vector<std::vector<VkSemaphore>> signalSemaphores(submissioncount);
-
-        for(size_t i{ 0 }; i < submissioncount; ++i) {
-            //Wait semaphores / stages
-            size_t const waitSemaphoreCount{ std::size(submissions[i].waitSemaphores) };
-            waitSemaphores[i].resize(waitSemaphoreCount);
-            waitStages[i].resize(waitSemaphoreCount);
-
-            for(size_t j = 0; j < waitSemaphoreCount; ++j) {
-                waitSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].waitSemaphores[j].first)->getSemaphore();
-                waitStages[i][j]     = convertStage(submissions[i].waitSemaphores[j].second);
-            }
-
-            //Command buffers
-            size_t const commandBufferCount{ std::size(submissions[i].commandBuffers) };
-            commandBuffers[i].resize(commandBufferCount);
-            for(size_t j = 0; j < commandBufferCount; ++j) {
-                commandBuffers[i][j] = polyCast<VulkanTransferCommandBuffer const>(submissions[i].commandBuffers[j])->getCommandBuffer();
-            }
-
-            //Signal semaphores
-            size_t const signalSemaphoreCount{ std::size(submissions[i].signalSemaphores) };
-            signalSemaphores[i].resize(signalSemaphoreCount);
-            for(size_t j = 0; j < signalSemaphoreCount; ++j) {
-                signalSemaphores[i][j] = polyCast<VulkanSemaphore const>(submissions[i].signalSemaphores[j])->getSemaphore();
-            }
-
-            vkSubmissions.emplace_back(VkSubmitInfo{
-                .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-                .waitSemaphoreCount   = static_cast<uint32_t>(waitSemaphoreCount),
-                .pWaitSemaphores      = std::data(waitSemaphores[i]),
-                .pWaitDstStageMask    = std::data(waitStages[i]),
-                .commandBufferCount   = static_cast<uint32_t>(commandBufferCount),
-                .pCommandBuffers      = std::data(commandBuffers[i]),
-                .signalSemaphoreCount = static_cast<uint32_t>(signalSemaphoreCount),
-                .pSignalSemaphores    = std::data(signalSemaphores[i]),
-            });
+        for(size_t i{ 0 }; i < waitSemaphoreCount; ++i) {
+            waitSemaphores[i] = polyCast<VulkanSemaphore const>(submission.waitSemaphores[i].first)->getSemaphore();
+            waitStages[i]     = convertStage(submission.waitSemaphores[i].second);
         }
+
+        //Command buffers
+        std::vector<VkCommandBuffer> commandBuffers{};
+        size_t const commandBufferCount{ submission.commandBuffers.size() };
+        commandBuffers.resize(commandBufferCount);
+        for(size_t i{ 0 }; i < commandBufferCount; ++i) {
+            commandBuffers[i] = polyCast<VulkanTransferCommandBuffer const>(submission.commandBuffers[i])->getCommandBuffer();
+        }
+
+        //Signal semaphores
+        std::vector<VkSemaphore> signalSemaphores{};
+        size_t const signalSemaphoreCount{ submission.signalSemaphores.size() };
+        signalSemaphores.resize(signalSemaphoreCount);
+        for(size_t i{ 0 }; i < signalSemaphoreCount; ++i) {
+            signalSemaphores[i] = polyCast<VulkanSemaphore const>(submission.signalSemaphores[i])->getSemaphore();
+        }
+
+        VkSubmitInfo const submitInfo{
+            .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+            .waitSemaphoreCount   = static_cast<uint32_t>(waitSemaphoreCount),
+            .pWaitSemaphores      = waitSemaphores.data(),
+            .pWaitDstStageMask    = waitStages.data(),
+            .commandBufferCount   = static_cast<uint32_t>(commandBufferCount),
+            .pCommandBuffers      = commandBuffers.data(),
+            .signalSemaphoreCount = static_cast<uint32_t>(signalSemaphoreCount),
+            .pSignalSemaphores    = signalSemaphores.data(),
+        };
 
         VkFence const vkFence{ signalFence != nullptr ? polyCast<VulkanFence const>(signalFence)->getFence() : VK_NULL_HANDLE };
 
-        if(vkQueueSubmit(queue, std::size(vkSubmissions), std::data(vkSubmissions), vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to submit graphics command buffer(s)");
+        uint32_t constexpr submitCount{ 1 };
+        if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
+            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to submit transfer command buffer(s)");
         }
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
@@ -52,10 +52,11 @@ namespace clove {
         return createGhaObject<VulkanTransferCommandBuffer>(commandBuffer, queueFamilyIndices);
     }
 
-    void VulkanTransferQueue::freeCommandBuffer(GhaTransferCommandBuffer &buffer) {
-        VkCommandBuffer const vkbuffer{ polyCast<VulkanTransferCommandBuffer>(&buffer)->getCommandBuffer() };
-
+    void VulkanTransferQueue::freeCommandBuffer(std::unique_ptr<GhaTransferCommandBuffer> &buffer) {
+        VkCommandBuffer const vkbuffer{ polyCast<VulkanTransferCommandBuffer>(buffer.get())->getCommandBuffer() };
         vkFreeCommandBuffers(device.get(), commandPool, 1, &vkbuffer);
+
+        buffer.reset();
     }
 
     void VulkanTransferQueue::submit(TransferSubmitInfo const &submission, GhaFence *signalFence) {

--- a/clove/source/Rendering/ForwardRenderer3D.cpp
+++ b/clove/source/Rendering/ForwardRenderer3D.cpp
@@ -141,9 +141,9 @@ namespace clove {
         for(auto &imageData : inFlightImageData) {
             imageData.frameDataBuffer.reset();
 
-            graphicsQueue->freeCommandBuffer(*imageData.commandBuffer);
-            graphicsQueue->freeCommandBuffer(*imageData.shadowMapCommandBuffer);
-            graphicsQueue->freeCommandBuffer(*imageData.cubeShadowMapCommandBuffer);
+            graphicsQueue->freeCommandBuffer(imageData.commandBuffer);
+            graphicsQueue->freeCommandBuffer(imageData.shadowMapCommandBuffer);
+            graphicsQueue->freeCommandBuffer(imageData.cubeShadowMapCommandBuffer);
         }
     }
 
@@ -500,10 +500,10 @@ namespace clove {
         frameBuffers.clear();
 
         for(auto &imageData : inFlightImageData) {
-            graphicsQueue->freeCommandBuffer(*imageData.commandBuffer);
-            graphicsQueue->freeCommandBuffer(*imageData.shadowMapCommandBuffer);
-            graphicsQueue->freeCommandBuffer(*imageData.cubeShadowMapCommandBuffer);
-            computeQueue->freeCommandBuffer(*imageData.skinningCommandBuffer);
+            graphicsQueue->freeCommandBuffer(imageData.commandBuffer);
+            graphicsQueue->freeCommandBuffer(imageData.shadowMapCommandBuffer);
+            graphicsQueue->freeCommandBuffer(imageData.cubeShadowMapCommandBuffer);
+            computeQueue->freeCommandBuffer(imageData.skinningCommandBuffer);
         }
     }
 

--- a/clove/source/Rendering/Renderables/Mesh.cpp
+++ b/clove/source/Rendering/Renderables/Mesh.cpp
@@ -22,7 +22,7 @@ namespace clove {
             transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
 
             transferQueueFinishedFence->wait();
-            transferQueue->freeCommandBuffer(*transferCommandBuffer);
+            transferQueue->freeCommandBuffer(transferCommandBuffer);
         }
     }
 
@@ -38,8 +38,8 @@ namespace clove {
         vertexOffset = 0;
         indexOffset  = vertexBufferSize;
 
-        auto transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
-        std::shared_ptr<GhaTransferCommandBuffer> transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
+        std::unique_ptr<GhaTransferQueue> transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
+        std::unique_ptr<GhaTransferCommandBuffer> transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
 
         //Staging buffer
         auto stagingBuffer{ *factory.createBuffer(GhaBuffer::Descriptor{
@@ -80,7 +80,7 @@ namespace clove {
         transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
 
         transferQueueFinishedFence->wait();
-        transferQueue->freeCommandBuffer(*transferCommandBuffer);
+        transferQueue->freeCommandBuffer(transferCommandBuffer);
     }
 
     Mesh::Mesh(Mesh const &other)

--- a/clove/source/Rendering/RenderingHelpers.cpp
+++ b/clove/source/Rendering/RenderingHelpers.cpp
@@ -271,10 +271,10 @@ namespace clove {
         graphicsQueue->submit({ GraphicsSubmitInfo{ .commandBuffers = { graphicsCommandBuffer.get() } } }, graphicsQueueFinishedFence.get());
 
         transferQueueFinishedFence->wait();
-        transferQueue->freeCommandBuffer(*transferCommandBuffer);
+        transferQueue->freeCommandBuffer(transferCommandBuffer);
 
         graphicsQueueFinishedFence->wait();
-        graphicsQueue->freeCommandBuffer(*graphicsCommandBuffer);
+        graphicsQueue->freeCommandBuffer(graphicsCommandBuffer);
 
         return image;
     }


### PR DESCRIPTION
## Summary
Refactored the GHA queue api to take only a single submission info. Also refactored the 'freeCommandBuffer' functions to reset the pointer that is passed into them. Make sure that the pointer is synchronised to the internal state of the command queue

Closes #352 
Closes #360 

## Changes
- GHA queues now only take a single submission struct
- GHA queues freeCommandBuffer function now takes a unique_ptr ref