### PR TITLE
Added proper alignment support to the allocators

### DIFF
--- a/clove/components/systems/ai/include/Clove/AI/BlackBoard.inl
+++ b/clove/components/systems/ai/include/Clove/AI/BlackBoard.inl
@@ -5,7 +5,7 @@ namespace clove {
     template<typename DataType>
     void BlackBoard::setValue(Key key, DataType value) {
         if(dataMap.find(key) == dataMap.end()) {
-            void *block = memoryBlock.alloc(sizeof(DataType));
+            void *block = memoryBlock.alloc<DataType>();
             if(block == nullptr) {
                 CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Could not allocate space for new item", CLOVE_FUNCTION_NAME);
                 return;

--- a/clove/components/utilities/memory/CMakeLists.txt
+++ b/clove/components/utilities/memory/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
 	CloveMemory STATIC
 		${INCLUDE}/AllocatorStrategy.hpp
         ${INCLUDE}/ListAllocator.hpp
+        ${INCLUDE}/ListAllocator.inl
 		${SOURCE}/ListAllocator.cpp
 		${INCLUDE}/PoolAllocator.hpp
 		${INCLUDE}/PoolAllocator.inl

--- a/clove/components/utilities/memory/CMakeLists.txt
+++ b/clove/components/utilities/memory/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
 		${INCLUDE}/PoolAllocator.hpp
 		${INCLUDE}/PoolAllocator.inl
 		${INCLUDE}/StackAllocator.hpp
+		${INCLUDE}/StackAllocator.inl
 		${SOURCE}/StackAllocator.cpp
 )
 

--- a/clove/components/utilities/memory/include/Clove/Memory/ListAllocator.hpp
+++ b/clove/components/utilities/memory/include/Clove/Memory/ListAllocator.hpp
@@ -15,18 +15,19 @@ namespace clove {
     class ListAllocator {
         //TYPES
     private:
-        struct Header {
-            size_t blockSize{ 0 };
+        struct Block {
+            bool free{ true };
+            size_t offset{ 0 };        /**< Offset into the backing memory of the block. */
+            size_t alignedOffset{ 0 }; /**< The offset into the backing memory that respects the allocation's alignment. */
+            size_t size{ 0 };          /**< Size of the entire block of memory. */
         };
 
         //VARIABLES
     private:
-        std::byte *rawList{ nullptr }; /**< The raw list to allocate from if there are no free blocks. */
-        size_t listSize{ 0 };
+        std::byte *backingMemory{ nullptr }; /**< Underlying memory of the free list. */
+        size_t backingMemorySize{ 0 };
 
-        std::byte *head{ nullptr };
-
-        std::list<Header *> freeList; /**< Keeps track of any previously allocated blocks that are now free. */
+        std::list<Block> freeList{}; /**< Current list of all free blocks on memory. */
 
         bool freeMemory{ true };
 

--- a/clove/components/utilities/memory/include/Clove/Memory/ListAllocator.hpp
+++ b/clove/components/utilities/memory/include/Clove/Memory/ListAllocator.hpp
@@ -21,11 +21,12 @@ namespace clove {
 
         //VARIABLES
     private:
-        std::byte *rawList;
+        std::byte *rawList{ nullptr }; /**< The raw list to allocate from if there are no free blocks. */
         size_t listSize{ 0 };
+
         std::byte *head{ nullptr };
 
-        std::list<Header *> list;
+        std::list<Header *> freeList; /**< Keeps track of any previously allocated blocks that are now free. */
 
         bool freeMemory{ true };
 
@@ -44,11 +45,23 @@ namespace clove {
         ~ListAllocator();
 
         /**
-         * @brief Allocates X bytes from the list.
+         * @brief Allocates size amounts of bytes from the list.
+         * @param size
+         * @param alignment
          * @returns A Pointer to the allocated block of memory.
          */
-        void *alloc(size_t bytes);
+        void *alloc(size_t size, size_t alignment);
+
+        /**
+         * @brief Allocate a block of memory for T.
+         * @tparam T 
+         * @return 
+         */
+        template<typename T>
+        T *alloc();
 
         void free(void *ptr);
     };
 }
+
+#include "ListAllocator.inl"

--- a/clove/components/utilities/memory/include/Clove/Memory/ListAllocator.inl
+++ b/clove/components/utilities/memory/include/Clove/Memory/ListAllocator.inl
@@ -1,0 +1,6 @@
+namespace clove {
+    template<typename T>
+    T *ListAllocator::alloc() {
+        return reinterpret_cast<T *>(alloc(sizeof(T), alignof(T)));
+    }
+}

--- a/clove/components/utilities/memory/include/Clove/Memory/StackAllocator.hpp
+++ b/clove/components/utilities/memory/include/Clove/Memory/StackAllocator.hpp
@@ -36,11 +36,26 @@ namespace clove {
         ~StackAllocator();
 
         /**
-         * @returns A marker of the current stack position of the allocator.
+         * @brief Creates a marker of the current stack position of the allocator.
+         * @returns 
          */
         Marker markPosition();
 
-        void *alloc(size_t bytes);
+        /**
+         * @brief Allocates a chunk of memory of the required size and alignment.
+         * @param size 
+         * @param alignment
+         * @return Pointer to the begining of the chunk of memory
+         */
+        void *alloc(size_t size, size_t alignment);
+
+        /**
+         * @brief Allocates enough memory for a type T.
+         * @tparam T 
+         * @return 
+         */
+        template<typename T>
+        T *alloc();
 
         /**
          * @brief Free the entire allocator, effectively resetting the stack.
@@ -48,7 +63,10 @@ namespace clove {
         void free();
         /**
          * @brief Free everything allocated after the marker.
+         * @param marker
          */
         void free(Marker marker);
     };
 }
+
+#include "StackAllocator.inl"

--- a/clove/components/utilities/memory/include/Clove/Memory/StackAllocator.inl
+++ b/clove/components/utilities/memory/include/Clove/Memory/StackAllocator.inl
@@ -1,0 +1,6 @@
+namespace clove {
+    template<typename T>
+    T *StackAllocator::alloc() {
+        return reinterpret_cast<T *>(alloc(sizeof(T), alignof(T)));
+    }
+}

--- a/clove/components/utilities/memory/source/ListAllocator.cpp
+++ b/clove/components/utilities/memory/source/ListAllocator.cpp
@@ -67,7 +67,7 @@ namespace clove {
             }
         }
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, size);
+        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
         return nullptr;
     }
 

--- a/clove/components/utilities/memory/source/ListAllocator.cpp
+++ b/clove/components/utilities/memory/source/ListAllocator.cpp
@@ -7,14 +7,14 @@ namespace clove {
     ListAllocator::ListAllocator(size_t sizeBytes)
         : backingMemorySize(sizeBytes) {
         backingMemory = reinterpret_cast<std::byte *>(malloc(backingMemorySize));
-        freeList.emplace_back(true, 0, 0, backingMemorySize);
+        freeList.emplace_back(Block{ .size = backingMemorySize });
     }
 
     ListAllocator::ListAllocator(std::byte *start, size_t sizeBytes)
         : backingMemorySize{ sizeBytes }
         , freeMemory{ false } {
         backingMemory = reinterpret_cast<std::byte *>(start);
-        freeList.emplace_back(true, 0, 0, backingMemorySize);
+        freeList.emplace_back(Block{ .size = backingMemorySize });
     }
 
     ListAllocator::ListAllocator(ListAllocator &&other) noexcept

--- a/clove/components/utilities/memory/source/ListAllocator.cpp
+++ b/clove/components/utilities/memory/source/ListAllocator.cpp
@@ -58,7 +58,7 @@ namespace clove {
         }
 
         if(header == nullptr) {
-            if((head - rawList) + totalAllocationSize > listSize) {
+            if((head - rawList) + sizeof(Header) + totalAllocationSize > listSize) {
                 CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, size);
                 return nullptr;
             }

--- a/clove/components/utilities/memory/source/ListAllocator.cpp
+++ b/clove/components/utilities/memory/source/ListAllocator.cpp
@@ -5,33 +5,31 @@
 
 namespace clove {
     ListAllocator::ListAllocator(size_t sizeBytes)
-        : listSize(sizeBytes) {
-        rawList = reinterpret_cast<std::byte *>(malloc(listSize));
-        head    = rawList;
+        : backingMemorySize(sizeBytes) {
+        backingMemory = reinterpret_cast<std::byte *>(malloc(backingMemorySize));
+        freeList.emplace_back(true, 0, 0, backingMemorySize);
     }
 
     ListAllocator::ListAllocator(std::byte *start, size_t sizeBytes)
-        : listSize(sizeBytes)
-        , freeMemory(false) {
-        rawList = reinterpret_cast<std::byte *>(start);
-        head    = rawList;
+        : backingMemorySize{ sizeBytes }
+        , freeMemory{ false } {
+        backingMemory = reinterpret_cast<std::byte *>(start);
+        freeList.emplace_back(true, 0, 0, backingMemorySize);
     }
 
     ListAllocator::ListAllocator(ListAllocator &&other) noexcept
-        : rawList{ other.rawList }
-        , listSize{ other.listSize }
-        , head{ other.head }
+        : backingMemory{ other.backingMemory }
+        , backingMemorySize{ other.backingMemorySize }
         , freeList{ std::move(other.freeList) }
         , freeMemory{ other.freeMemory } {
         other.freeMemory = false;
     }
 
     ListAllocator &ListAllocator::operator=(ListAllocator &&other) noexcept {
-        rawList    = other.rawList;
-        listSize   = other.listSize;
-        head       = other.head;
-        freeList       = std::move(freeList);
-        freeMemory = other.freeMemory;
+        backingMemory     = other.backingMemory;
+        backingMemorySize = other.backingMemorySize;
+        freeList          = std::move(freeList);
+        freeMemory        = other.freeMemory;
 
         other.freeMemory = false;
 
@@ -40,46 +38,71 @@ namespace clove {
 
     ListAllocator::~ListAllocator() {
         if(freeMemory) {
-            ::free(rawList);
+            ::free(backingMemory);
         }
     }
 
     void *ListAllocator::alloc(size_t size, size_t alignment) {
         size_t const totalAllocationSize{ size + alignment };
 
-        Header *header{ nullptr };
-        for(auto *freeHeader : freeList) {
-            if(freeHeader->blockSize >= totalAllocationSize) {
-                header = freeHeader;
-                freeList.remove(header);
-                break;
-                //TODO: Can reduce fragmentation by putting remaining bytes back in the list
+        for(auto block{ freeList.begin() }; block != freeList.end(); ++block) {
+            if(block->free && block->size >= totalAllocationSize) {
+                block->free = false;
+
+                if(size_t const remainingSpace{ block->size - totalAllocationSize }; remainingSpace > 0) {
+                    block->size = totalAllocationSize;
+
+                    freeList.insert(std::next(block), Block{
+                                                          .offset = block->offset + block->size,
+                                                          .size   = remainingSpace,
+                                                      });
+                }
+
+                size_t const remainingAlignment{ alignment != 0 ? block->offset % alignment : 0 };
+                size_t const alignmentOffset{ remainingAlignment != 0 ? alignment - remainingAlignment : 0 };
+
+                block->alignedOffset = block->offset + alignmentOffset;
+
+                return backingMemory + block->alignedOffset;
             }
         }
 
-        if(header == nullptr) {
-            if((head - rawList) + sizeof(Header) + totalAllocationSize > listSize) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, size);
-                return nullptr;
-            }
-
-            header            = reinterpret_cast<Header *>(head);
-            header->blockSize = totalAllocationSize;
-            head += sizeof(Header) + totalAllocationSize;
-        }
-
-        //Get a pointer to the piece of memory after the header. Cast to uint8_t so the + operator knows how many bytes to advance by.
-        uint8_t *memory{ reinterpret_cast<uint8_t *>(header) + sizeof(Header) };
-
-        size_t const remainingAlignment{ alignment != 0 ? reinterpret_cast<uintptr_t>(memory) % alignment : 0 };
-        size_t const alignmentOffset{ remainingAlignment != 0 ? alignment - remainingAlignment : 0 };
-        return memory + alignmentOffset;
+        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, size);
+        return nullptr;
     }
 
     void ListAllocator::free(void *ptr) {
-        std::byte *data{ reinterpret_cast<std::byte *>(ptr) };
-        Header *header{ reinterpret_cast<Header *>(data - sizeof(Header)) };
+        if(ptr == nullptr) {
+            return;
+        }
 
-        freeList.push_back(header);
+        for(auto block{ freeList.begin() }; block != freeList.end(); ++block) {
+            if(backingMemory + block->alignedOffset == ptr) {
+                block->free = true;
+
+                bool removeIndex{ false };
+                bool removeRight{ false };
+
+                if(auto rightBlock{ std::next(block) }; rightBlock != freeList.end() && rightBlock->free) {
+                    block->size += rightBlock->size;
+                    removeRight = true;
+                }
+                if(block != freeList.begin()) {
+                    if(auto leftBlock{ std::prev(block) }; leftBlock->free) {
+                        leftBlock->size += block->size;
+                        removeIndex = true;
+                    }
+                }
+
+                if(removeRight) {
+                    freeList.erase(std::next(block));
+                }
+                if(removeIndex) {
+                    freeList.erase(block);
+                }
+
+                break;
+            }
+        }
     }
 }

--- a/clove/components/utilities/memory/source/StackAllocator.cpp
+++ b/clove/components/utilities/memory/source/StackAllocator.cpp
@@ -32,14 +32,20 @@ namespace clove {
         return top - stack;
     }
 
-    void *StackAllocator::alloc(size_t bytes) {
-        if((top - stack) + bytes > stackSize) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, bytes);
+    void *StackAllocator::alloc(size_t size, size_t alignment) {
+        size_t const totalAllocationSize{ size + alignment };
+
+        if((top - stack) + totalAllocationSize > stackSize) {
+            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
             return nullptr;
         }
 
-        void *element = top;
-        top += bytes;
+        size_t const remainingAlignment{ alignment != 0 ? reinterpret_cast<uintptr_t>(top) % alignment : 0 };
+        size_t const alignmentOffset{ remainingAlignment != 0 ? alignment - remainingAlignment : 0 };
+
+        void *element{ top + alignmentOffset };
+        top += totalAllocationSize;
+
         return element;
     }
 

--- a/clove/components/utilities/memory/tests/ListAllocatorTests.cpp
+++ b/clove/components/utilities/memory/tests/ListAllocatorTests.cpp
@@ -5,34 +5,84 @@
 using namespace clove;
 
 TEST(ListAllocatorTests, CanAllocateAnAmountOfBytes) {
-    const size_t allocatorSize = 256 * 1024;//256kb
+    size_t constexpr allocatorSize{ 256 * 1024 };//256kb
     ListAllocator allocator(allocatorSize);
 
-    void* data = allocator.alloc(100);
+    void *data1{ allocator.alloc(100, 0) };
+    uint32_t *data2{ allocator.alloc<uint32_t>() };
 
-    EXPECT_TRUE(data != nullptr);
+    EXPECT_TRUE(data1 != nullptr);
+    EXPECT_TRUE(data2 != nullptr);
+}
+
+TEST(ListAllocatorTests, AllocationsAreProperlyAligned) {
+    size_t constexpr allocatorSize{ 256 * 1024 };//256kb
+    ListAllocator allocator(allocatorSize);
+
+    size_t constexpr alignment{ 16 };
+
+    void *data1{ allocator.alloc(100, alignment) };
+    uint32_t *data2{ allocator.alloc<uint32_t>() };
+
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(data1) % alignment, 0);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(data2) % alignof(uint32_t), 0);
+}
+
+TEST(ListAllocatorTests, MultipleAllocationsDoNotOverlap) {
+    size_t constexpr allocatorSize{ 256 * 1024 };//256kb
+    ListAllocator allocator(allocatorSize);
+
+    size_t constexpr alignment{ 16 };
+
+    auto *data1{ allocator.alloc<uint32_t>() };
+    auto *data2{ allocator.alloc<uint64_t>() };
+    auto *data3{ allocator.alloc<float>() };
+    auto *data4{ allocator.alloc<uint8_t>() };
+    auto *data5{ allocator.alloc<uint32_t>() };
+    auto *data6{ allocator.alloc<uint32_t>() };
+
+    uint32_t constexpr data1Value{ 100000000 };
+    uint64_t constexpr data2Value{ 12345678987654321 };
+    float constexpr data3Value{ 3.13754943 };
+    uint8_t constexpr data4Value{ 19 };
+    uint32_t constexpr data5Value{ 10001 };
+    uint32_t constexpr data6Value{ 1002 };
+
+    *data1 = data1Value;
+    *data2 = data2Value;
+    *data3 = data3Value;
+    *data4 = data4Value;
+    *data5 = data5Value;
+    *data6 = data6Value;
+
+    EXPECT_EQ(*data1, data1Value);
+    EXPECT_EQ(*data2, data2Value);
+    EXPECT_EQ(*data3, data3Value);
+    EXPECT_EQ(*data4, data4Value);
+    EXPECT_EQ(*data5, data5Value);
+    EXPECT_EQ(*data6, data6Value);
 }
 
 TEST(ListAllocatorTests, CannotAllocateMoreThanTheAllocatorHas) {
-    const size_t allocatorSize = 256 * 1024;//256kb
+    size_t constexpr allocatorSize{ 256 * 1024 };//256kb
     ListAllocator allocator(allocatorSize);
 
-    void* data = allocator.alloc(allocatorSize + 1);
+    void *data{ allocator.alloc(allocatorSize + 1, 0) };
 
     EXPECT_FALSE(data != nullptr);
 }
 
 TEST(ListAllocatorTests, CanFreeAndReallocateBytes) {
-    const size_t allocatorSize = 256 * 1024;//256kb
+    size_t constexpr allocatorSize{ 256 * 1024 };//256kb
     ListAllocator allocator(allocatorSize);
 
-    void* allData = allocator.alloc(allocatorSize);
+    void *allData{ allocator.alloc(allocatorSize, 0) };
 
     EXPECT_TRUE(allData != nullptr);
 
     allocator.free(allData);
 
-    void* someData = allocator.alloc(500);
+    void *someData{ allocator.alloc(500, 0) };
 
     EXPECT_TRUE(someData != nullptr);
 }
@@ -41,23 +91,23 @@ TEST(ListAllocatorTests, CanInitialiseWithARangeOfMemory) {
     std::array<std::byte, 256 * 1024> allocatorRange;
     ListAllocator allocator(allocatorRange.data(), allocatorRange.size());
 
-    void* data = allocator.alloc(100);
+    void *data{ allocator.alloc(100, 0) };
 
     EXPECT_TRUE(data != nullptr);
 }
 
 TEST(ListAllocatorTests, FreeWillFreeAndReallocTheCorrectRange) {
-    const size_t allocatorSize = 256 * 1024;//256kb
+    size_t constexpr allocatorSize{ 256 * 1024 };//256kb
     ListAllocator allocator(allocatorSize);
 
-    const uint32_t value = 5;
+    uint32_t constexpr value{ 5 };
 
-    uint32_t* first = reinterpret_cast<uint32_t*>(allocator.alloc(sizeof(uint32_t)));
-    *first          = value;
+    uint32_t *first{ allocator.alloc<uint32_t>() };
+    *first = value;
 
     allocator.free(first);
 
-    uint32_t* second = reinterpret_cast<uint32_t*>(allocator.alloc(sizeof(uint32_t)));
+    uint32_t *second{ allocator.alloc<uint32_t>() };
 
     EXPECT_EQ(value, *second);
 }


### PR DESCRIPTION
## Summary
When allocation from `ListAllocator` and `StackAllocator` an alignment for the allocation is also required. Template overloads were also added to make the process easier if allocating space for a single object.

This change also includes are refactor for `ListAllocator` to stop including the header data of the chuck inside the memory for the allocations itself. This will free up the entire backing buffer to be used for allocations along with making the allocator more robust in general.

Closes #270 

## Changes
- ListAllocator now properly aligns it's allocations
- Fixed an issue with ListAllocator where head be greater than list end
- Refactored ListAllocator to stop storing headers in the backing memory
- StackAllocator now properly aligns allocations
