### PR TITLE
Logging and assertion refactors

### DIFF
--- a/bulb/components/membrane/include/Membrane/MembraneLog.hpp
+++ b/bulb/components/membrane/include/Membrane/MembraneLog.hpp
@@ -2,4 +2,4 @@
 
 #include <Clove/Log/Log.hpp>
 
-CLOVE_DECLARE_LOG_CATEGORY(MEMBRANE)
+CLOVE_DECLARE_LOG_CATEGORY(Membrane)

--- a/bulb/components/membrane/source/Log.cpp
+++ b/bulb/components/membrane/source/Log.cpp
@@ -8,7 +8,7 @@
 #include <spdlog/pattern_formatter.h>
 
 //Making the assumption that this library will only be used with Bulb
-CLOVE_DECLARE_LOG_CATEGORY(BULB);
+CLOVE_DECLARE_LOG_CATEGORY(Bulb);
 
 namespace membrane {
     namespace {
@@ -62,7 +62,7 @@ namespace membrane {
     }
 
     void Log::write(LogLevel level, System::String ^ message) {
-        CLOVE_LOG(LOG_CATEGORY_BULB, convertLevel(level), msclr::interop::marshal_as<std::string>(message));
+        CLOVE_LOG(Bulb, convertLevel(level), msclr::interop::marshal_as<std::string>(message));
     }
 
     void Log::addSink(LogSink ^ sink, System::String ^ pattern) {

--- a/bulb/components/membrane/source/MessageHandler.cpp
+++ b/bulb/components/membrane/source/MessageHandler.cpp
@@ -30,7 +30,7 @@ namespace membrane {
         } else if (baseType == EngineMessage::typeid) {
             engineMessages->Add((EngineMessage^)message);
         } else {
-            CLOVE_LOG(LOG_CATEGORY_MEMBRANE, clove::LogLevel::Warning, "{0} called with neither an Editor or Engine message! Base type is: {1}", CLOVE_FUNCTION_NAME_PRETTY, msclr::interop::marshal_as<std::string>(baseType->Name));
+            CLOVE_LOG(Membrane, clove::LogLevel::Warning, "{0} called with neither an Editor or Engine message! Base type is: {1}", CLOVE_FUNCTION_NAME_PRETTY, msclr::interop::marshal_as<std::string>(baseType->Name));
         }
     }
 

--- a/clove/CMakeLists.txt
+++ b/clove/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(
 		${INCLUDE}/Rendering/RenderingConstants.hpp
 		${INCLUDE}/Rendering/RenderingHelpers.hpp
 		${SOURCE}/Rendering/RenderingHelpers.cpp
+		${INCLUDE}/Rendering/RenderingLog.hpp
 		${INCLUDE}/Rendering/RenderTarget.hpp
 		${INCLUDE}/Rendering/SwapchainRenderTarget.hpp
 		${SOURCE}/Rendering/SwapchainRenderTarget.cpp

--- a/clove/components/core/audio/CMakeLists.txt
+++ b/clove/components/core/audio/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
 	${SOURCE}/OpenAL/OpenAlFactory.cpp
 	${INCLUDE}/OpenAL/OpenAlListener.hpp
 	${SOURCE}/OpenAL/OpenAlListener.cpp
+	${INCLUDE}/OpenAL/OpenAlLog.hpp
 	${INCLUDE}/OpenAL/OpenAlSource.hpp
 	${SOURCE}/OpenAL/OpenAlSource.cpp
 )

--- a/clove/components/core/audio/include/Clove/Audio/OpenAL/OpenAlLog.hpp
+++ b/clove/components/core/audio/include/Clove/Audio/OpenAL/OpenAlLog.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <Clove/Log/Log.hpp>
+
+CLOVE_DECLARE_LOG_CATEGORY(OpenAl)
+CLOVE_DECLARE_LOG_CATEGORY(CloveAhaOpenAl)

--- a/clove/components/core/audio/source/OpenAL/OpenAlDevice.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlDevice.cpp
@@ -1,30 +1,28 @@
 #include "Clove/Audio/OpenAL/OpenAlDevice.hpp"
 
 #include "Clove/Audio/OpenAL/OpenAlFactory.hpp"
+#include "Clove/Audio/OpenAL/OpenAlLog.hpp"
 
 #include <AL/al.h>
-#include <Clove/Log/Log.hpp>
-
-CLOVE_DECLARE_LOG_CATEGORY(OpenalApi)
 
 namespace clove {
     namespace {
         void printErrorAlc(ALenum error, std::string_view const fileName, uint_fast32_t const line) {
             switch(error) {
                 case ALC_INVALID_VALUE:
-                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenAl, LogLevel::Error, "ALC_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_INVALID_DEVICE:
-                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_DEVICE: A bad device was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenAl, LogLevel::Error, "ALC_INVALID_DEVICE: A bad device was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_INVALID_CONTEXT:
-                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_CONTEXT: A bad context was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenAl, LogLevel::Error, "ALC_INVALID_CONTEXT: A bad context was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_INVALID_ENUM:
-                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_ENUM: An unkown enum was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenAl, LogLevel::Error, "ALC_INVALID_ENUM: An unkown enum was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_OUT_OF_MEMORY:
-                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenAl, LogLevel::Error, "ALC_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
                     break;
             }
         }
@@ -43,7 +41,7 @@ namespace clove {
         : factory{ std::make_shared<OpenAlFactory>() } {
         alDevice = alcOpenDevice(nullptr);
         if(alDevice == nullptr) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to create OpenAL device");
+            CLOVE_LOG(CloveAhaOpenAl, LogLevel::Error, "Failed to create OpenAL device");
             return;
         }
 

--- a/clove/components/core/audio/source/OpenAL/OpenAlDevice.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlDevice.cpp
@@ -5,26 +5,26 @@
 #include <AL/al.h>
 #include <Clove/Log/Log.hpp>
 
-CLOVE_DECLARE_LOG_CATEGORY(OPENAL)
+CLOVE_DECLARE_LOG_CATEGORY(OpenalApi)
 
 namespace clove {
     namespace {
         void printErrorAlc(ALenum error, std::string_view const fileName, uint_fast32_t const line) {
             switch(error) {
                 case ALC_INVALID_VALUE:
-                    CLOVE_LOG(LOG_CATEGORY_OPENAL, LogLevel::Error, "ALC_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_INVALID_DEVICE:
-                    CLOVE_LOG(LOG_CATEGORY_OPENAL, LogLevel::Error, "ALC_INVALID_DEVICE: A bad device was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_DEVICE: A bad device was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_INVALID_CONTEXT:
-                    CLOVE_LOG(LOG_CATEGORY_OPENAL, LogLevel::Error, "ALC_INVALID_CONTEXT: A bad context was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_CONTEXT: A bad context was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_INVALID_ENUM:
-                    CLOVE_LOG(LOG_CATEGORY_OPENAL, LogLevel::Error, "ALC_INVALID_ENUM: An unkown enum was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_INVALID_ENUM: An unkown enum was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                     break;
                 case ALC_OUT_OF_MEMORY:
-                    CLOVE_LOG(LOG_CATEGORY_OPENAL, LogLevel::Error, "ALC_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
+                    CLOVE_LOG(OpenalApi, LogLevel::Error, "ALC_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
                     break;
             }
         }
@@ -43,7 +43,7 @@ namespace clove {
         : factory{ std::make_shared<OpenAlFactory>() } {
         alDevice = alcOpenDevice(nullptr);
         if(alDevice == nullptr) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create OpenAL device");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to create OpenAL device");
             return;
         }
 

--- a/clove/components/core/audio/source/OpenAL/OpenAlError.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlError.cpp
@@ -1,25 +1,26 @@
 #include "Clove/Audio/OpenAL/OpenAlError.hpp"
 
+#include "Clove/Audio/OpenAL/OpenAlLog.hpp"
+
 #include <AL/alc.h>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     void printErrorAl(ALenum error, std::string_view const fileName, uint_fast32_t const line) {
         switch(error) {
             case AL_INVALID_NAME:
-                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_NAME: A bad name (id) was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(OpenAl, LogLevel::Error, "AL_INVALID_NAME: A bad name (id) was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                 break;
             case AL_INVALID_ENUM:
-                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_ENUM: An invalid enum value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(OpenAl, LogLevel::Error, "AL_INVALID_ENUM: An invalid enum value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                 break;
             case AL_INVALID_VALUE:
-                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(OpenAl, LogLevel::Error, "AL_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                 break;
             case AL_INVALID_OPERATION:
-                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_OPERATION: The requested operation was not valid. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(OpenAl, LogLevel::Error, "AL_INVALID_OPERATION: The requested operation was not valid. File: {0} Line {1}", fileName, line);
                 break;
             case AL_OUT_OF_MEMORY:
-                CLOVE_LOG(Clove, LogLevel::Error, "AL_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(OpenAl, LogLevel::Error, "AL_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
                 break;
         }
     }

--- a/clove/components/core/audio/source/OpenAL/OpenAlError.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlError.cpp
@@ -7,19 +7,19 @@ namespace clove {
     void printErrorAl(ALenum error, std::string_view const fileName, uint_fast32_t const line) {
         switch(error) {
             case AL_INVALID_NAME:
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "AL_INVALID_NAME: A bad name (id) was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_NAME: A bad name (id) was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                 break;
             case AL_INVALID_ENUM:
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "AL_INVALID_ENUM: An invalid enum value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_ENUM: An invalid enum value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                 break;
             case AL_INVALID_VALUE:
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "AL_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_VALUE: An invalid value was passed to an OpenAL function. File: {0} Line {1}", fileName, line);
                 break;
             case AL_INVALID_OPERATION:
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "AL_INVALID_OPERATION: The requested operation was not valid. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(Clove, LogLevel::Error, "AL_INVALID_OPERATION: The requested operation was not valid. File: {0} Line {1}", fileName, line);
                 break;
             case AL_OUT_OF_MEMORY:
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "AL_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
+                CLOVE_LOG(Clove, LogLevel::Error, "AL_OUT_OF_MEMORY: The requested operation caused OpenAL to run out of memory. File: {0} Line {1}", fileName, line);
                 break;
         }
     }

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -2,10 +2,10 @@
 
 #include "Clove/Audio/OpenAL/OpenAlBuffer.hpp"
 #include "Clove/Audio/OpenAL/OpenAlError.hpp"
+#include "Clove/Audio/OpenAL/OpenAlLog.hpp"
 
 #include <Clove/Cast.hpp>
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 #include <set>
 
 namespace clove {
@@ -25,7 +25,7 @@ namespace clove {
         OpenAlBuffer const *const alBuffer{ polyCast<OpenAlBuffer const>(buffer.get()) };
 
         if(alBuffer == nullptr) {
-            CLOVE_LOG(Clove, LogLevel::Error, "{0} called with nullptr", CLOVE_FUNCTION_NAME_PRETTY);
+            CLOVE_LOG(CloveAhaOpenAl, LogLevel::Error, "{0} called with nullptr", CLOVE_FUNCTION_NAME_PRETTY);
             return;
         }
 
@@ -43,7 +43,7 @@ namespace clove {
             if(alBuffer != nullptr) {
                 alBuffers[i] = alBuffer->getBufferId();
             } else {
-                CLOVE_LOG(Clove, LogLevel::Error, "{0}: Buffer at index {1} is nullptr. Audio playback is likely affected", CLOVE_FUNCTION_NAME_PRETTY, i);
+                CLOVE_LOG(CloveAhaOpenAl, LogLevel::Error, "{0}: Buffer at index {1} is nullptr. Audio playback is likely affected", CLOVE_FUNCTION_NAME_PRETTY, i);
             }
         }
 
@@ -60,7 +60,7 @@ namespace clove {
 #if CLOVE_AHA_VALIDATION
             CLOVE_ASSERT(numToUnqueue <= maxAbleToUnQueue, "{0}: Can't unqueue {1} buffers. Only {2} buffers have been processed", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
 #else
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "{0}: {1} buffers attempted to unqueue but only {2} are avaiable. Clamping to {2}", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
+            CLOVE_LOG(CloveAhaOpenAl, LogLevel::Warning, "{0}: {1} buffers attempted to unqueue but only {2} are avaiable. Clamping to {2}", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
             numToUnqueue = maxAbleToUnQueue;
 #endif
         }
@@ -79,7 +79,7 @@ namespace clove {
             OpenAlBuffer const *const alBuffer{ polyCast<OpenAlBuffer const>(buffer.get()) };
 
             if(alBuffer == nullptr) {
-                CLOVE_LOG(Clove, LogLevel::Warning, "nullptr buffer found when un queueing buffers");
+                CLOVE_LOG(CloveAhaOpenAl, LogLevel::Warning, "nullptr buffer found when un queueing buffers");
                 return true;
             }
 

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -25,7 +25,7 @@ namespace clove {
         OpenAlBuffer const *const alBuffer{ polyCast<OpenAlBuffer const>(buffer.get()) };
 
         if(alBuffer == nullptr) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0} called with nullptr", CLOVE_FUNCTION_NAME_PRETTY);
+            CLOVE_LOG(Clove, LogLevel::Error, "{0} called with nullptr", CLOVE_FUNCTION_NAME_PRETTY);
             return;
         }
 
@@ -43,7 +43,7 @@ namespace clove {
             if(alBuffer != nullptr) {
                 alBuffers[i] = alBuffer->getBufferId();
             } else {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Buffer at index {1} is nullptr. Audio playback is likely affected", CLOVE_FUNCTION_NAME_PRETTY, i);
+                CLOVE_LOG(Clove, LogLevel::Error, "{0}: Buffer at index {1} is nullptr. Audio playback is likely affected", CLOVE_FUNCTION_NAME_PRETTY, i);
             }
         }
 
@@ -79,7 +79,7 @@ namespace clove {
             OpenAlBuffer const *const alBuffer{ polyCast<OpenAlBuffer const>(buffer.get()) };
 
             if(alBuffer == nullptr) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "nullptr buffer found when un queueing buffers");
+                CLOVE_LOG(Clove, LogLevel::Warning, "nullptr buffer found when un queueing buffers");
                 return true;
             }
 

--- a/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
+++ b/clove/components/core/audio/source/OpenAL/OpenAlSource.cpp
@@ -58,7 +58,7 @@ namespace clove {
         {
             const uint32_t maxAbleToUnQueue{ getNumBuffersProcessed() };
 #if CLOVE_AHA_VALIDATION
-            CLOVE_ASSERT(numToUnqueue <= maxAbleToUnQueue, "{0}: Can't unqueue {1} buffers. Only {2} buffers have been processed", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
+            CLOVE_ASSERT_MSG(numToUnqueue <= maxAbleToUnQueue, "{0}: Can't unqueue {1} buffers. Only {2} buffers have been processed", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
 #else
             CLOVE_LOG(CloveAhaOpenAl, LogLevel::Warning, "{0}: {1} buffers attempted to unqueue but only {2} are avaiable. Clamping to {2}", CLOVE_FUNCTION_NAME_PRETTY, numToUnqueue, maxAbleToUnQueue);
             numToUnqueue = maxAbleToUnQueue;

--- a/clove/components/core/graphics/CMakeLists.txt
+++ b/clove/components/core/graphics/CMakeLists.txt
@@ -64,6 +64,7 @@ set(
 		${INCLUDE}/Vulkan/VulkanImageView.hpp
 		${INCLUDE}/Vulkan/VulkanImageView.inl
 		${SOURCE}/Vulkan/VulkanImageView.cpp
+		${INCLUDE}/Vulkan/VulkanLog.hpp
 		${INCLUDE}/Vulkan/VulkanMemoryBarrier.hpp
 		${SOURCE}/Vulkan/VulkanMemoryBarrier.cpp
 		${INCLUDE}/Vulkan/VulkanPipelineObject.hpp
@@ -132,6 +133,7 @@ set(
 		${SOURCE}/Metal/MetalImage.mm
 		${INCLUDE}/Metal/MetalImageView.hpp
 		${SOURCE}/Metal/MetalImageView.mm
+		${INCLUDE}/Metal/MetalLog.hpp
 		${INCLUDE}/Metal/MetalPipelineObject.hpp
 		${SOURCE}/Metal/MetalPipelineObject.mm
 		${INCLUDE}/Metal/MetalPresentQueue.hpp

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalLog.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalLog.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Clove/Log/Log.hpp>
+
+CLOVE_DECLARE_LOG_CATEGORY(CloveGhaMetal)

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationBuffer.inl
@@ -5,14 +5,14 @@
 namespace clove {
     template<typename BaseBufferType>
     void ValidationBuffer<BaseBufferType>::write(void const *data, size_t const offset, size_t const size) {
-        CLOVE_ASSERT(BaseBufferType::getDescriptor().memoryType == MemoryType::SystemMemory, "{0}: Can only write to SystemMemory buffers", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(BaseBufferType::getDescriptor().memoryType == MemoryType::SystemMemory, "{0}: Can only write to SystemMemory buffers", CLOVE_FUNCTION_NAME_PRETTY);
 
         BaseBufferType::write(data, offset, size);
     }
 
     template<typename BaseBufferType>
     void ValidationBuffer<BaseBufferType>::read(void *data, size_t const offset, size_t const size) {
-        CLOVE_ASSERT(BaseBufferType::getDescriptor().memoryType == MemoryType::SystemMemory, "{0}: Can only read from SystemMemory buffers", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(BaseBufferType::getDescriptor().memoryType == MemoryType::SystemMemory, "{0}: Can only read from SystemMemory buffers", CLOVE_FUNCTION_NAME_PRETTY);
 
         BaseBufferType::read(data, offset, size);
     }

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationLog.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationLog.hpp
@@ -2,4 +2,4 @@
 
 #include <Clove/Log/Log.hpp>
 
-CLOVE_DECLARE_LOG_CATEGORY(CLOVE_GHA_VALIDATION)
+CLOVE_DECLARE_LOG_CATEGORY(CloveGhaValidation)

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.inl
@@ -13,7 +13,7 @@ namespace clove {
             for(auto &commandBuffer : submission.commandBuffers) {
                 auto *buffer{ dynamic_cast<ValidationCommandBuffer *>(commandBuffer) };
                 if(buffer->getCommandBufferUsage() == CommandBufferUsage::OneTimeSubmit && buffer->bufferHasBeenUsed()) {
-                    CLOVE_ASSERT(false, "GraphicsCommandBuffer recorded with CommandBufferUsage::OneTimeSubmit has already been used. Only buffers recorded with CommandBufferUsage::Default can submitted multiples times after being recorded once.");
+                    CLOVE_ASSERT_MSG(false, "GraphicsCommandBuffer recorded with CommandBufferUsage::OneTimeSubmit has already been used. Only buffers recorded with CommandBufferUsage::Default can submitted multiples times after being recorded once.");
                     break;
                 }
             }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanLog.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanLog.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Clove/Log/Log.hpp>
+
+CLOVE_DECLARE_LOG_CATEGORY(CloveGhaVulkan)

--- a/clove/components/core/graphics/source/Graphics.cpp
+++ b/clove/components/core/graphics/source/Graphics.cpp
@@ -18,7 +18,7 @@
 namespace clove {
     std::unique_ptr<GhaDevice> createGraphicsDevice(GraphicsApi api, std::any nativeWindow) {
 #if CLOVE_GHA_VALIDATION
-        CLOVE_LOG(LOG_CATEGORY_CLOVE_GHA_VALIDATION, LogLevel::Debug, "GHA validation enabled.");
+        CLOVE_LOG(CloveGhaValidation, LogLevel::Debug, "GHA validation enabled.");
 #endif
 
         switch(api) {

--- a/clove/components/core/graphics/source/Graphics.cpp
+++ b/clove/components/core/graphics/source/Graphics.cpp
@@ -33,7 +33,7 @@ namespace clove {
                 return std::make_unique<VulkanDevice>(std::move(nativeWindow));
 #endif
             default:
-                CLOVE_ASSERT("Default statement hit. Could not initialise RenderAPI: {0}", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "Default statement hit. Could not initialise RenderAPI: {0}", CLOVE_FUNCTION_NAME);
                 return nullptr;
         }
     }

--- a/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
@@ -4,6 +4,7 @@
 #include "Clove/Graphics/Metal/MetalComputeCommandBuffer.hpp"
 #include "Clove/Graphics/Metal/MetalSemaphore.hpp"
 #include "Clove/Graphics/Metal/MetalFence.hpp"
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 #include <Clove/Cast.hpp>
 
@@ -38,7 +39,7 @@ namespace clove {
                 
                 auto *metalCommandBuffer{ polyCast<MetalComputeCommandBuffer>(commandBuffer) };
                 if(metalCommandBuffer == nullptr) {
-                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                     continue;
                 }
                 
@@ -49,7 +50,7 @@ namespace clove {
                 for (auto const &semaphore : submission.waitSemaphores) {
                     auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                     if(metalSemaphore == nullptr) {
-                        CLOVE_LOG(Clove, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                        CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
                     }
                     

--- a/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalComputeQueue.mm
@@ -38,7 +38,7 @@ namespace clove {
                 
                 auto *metalCommandBuffer{ polyCast<MetalComputeCommandBuffer>(commandBuffer) };
                 if(metalCommandBuffer == nullptr) {
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                     continue;
                 }
                 
@@ -49,7 +49,7 @@ namespace clove {
                 for (auto const &semaphore : submission.waitSemaphores) {
                     auto const *metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                     if(metalSemaphore == nullptr) {
-                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                        CLOVE_LOG(Clove, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
                     }
                     

--- a/clove/components/core/graphics/source/Metal/MetalDescriptorPool.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDescriptorPool.mm
@@ -2,6 +2,7 @@
 
 #include "Clove/Graphics/Metal/MetalDescriptorSet.hpp"
 #include "Clove/Graphics/Metal/MetalDescriptorSetLayout.hpp"
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 #include <Clove/Cast.hpp>
 
@@ -124,7 +125,7 @@ namespace clove {
         for(auto const &descriptorSet : descriptorSets) {
             auto const *const mtlDescriptorSet{ polyCast<MetalDescriptorSet const>(descriptorSet) };
             if(mtlDescriptorSet == nullptr) {
-                CLOVE_LOG(Clove, LogLevel::Warning, "{0}: Descriptor set provided is nullptr. Buffers might never be freed", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveGhaMetal, LogLevel::Warning, "{0}: Descriptor set provided is nullptr. Buffers might never be freed", CLOVE_FUNCTION_NAME);
                 continue;
             }
             

--- a/clove/components/core/graphics/source/Metal/MetalDescriptorPool.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDescriptorPool.mm
@@ -124,7 +124,7 @@ namespace clove {
         for(auto const &descriptorSet : descriptorSets) {
             auto const *const mtlDescriptorSet{ polyCast<MetalDescriptorSet const>(descriptorSet) };
             if(mtlDescriptorSet == nullptr) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "{0}: Descriptor set provided is nullptr. Buffers might never be freed", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(Clove, LogLevel::Warning, "{0}: Descriptor set provided is nullptr. Buffers might never be freed", CLOVE_FUNCTION_NAME);
                 continue;
             }
             

--- a/clove/components/core/graphics/source/Metal/MetalDescriptorSet.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDescriptorSet.mm
@@ -62,7 +62,7 @@ namespace clove {
             }
         }
         
-        CLOVE_ASSERT(false, "{0}: Could not find binding", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(false, "{0}: Could not find binding", CLOVE_FUNCTION_NAME_PRETTY);
         return GhaShader::Stage::Vertex;
     }
 }

--- a/clove/components/core/graphics/source/Metal/MetalFactory.mm
+++ b/clove/components/core/graphics/source/Metal/MetalFactory.mm
@@ -40,7 +40,7 @@ namespace clove {
                 case VertexAttributeFormat::R32G32B32A32_SINT:
                     return MTLVertexFormatInt4;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown format passed", CLOVE_FUNCTION_NAME_PRETTY);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown format passed", CLOVE_FUNCTION_NAME_PRETTY);
                     return MTLVertexFormatFloat;
             }
         }
@@ -62,7 +62,7 @@ namespace clove {
                         return MTLTextureTypeCube;
                     }
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown type passed", CLOVE_FUNCTION_NAME_PRETTY);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown type passed", CLOVE_FUNCTION_NAME_PRETTY);
                     return MTLTextureType2D;
             }
         }
@@ -98,7 +98,7 @@ namespace clove {
                 case LoadOperation::DontCare:
                     return MTLLoadActionDontCare;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
                     return MTLLoadActionDontCare;
             }
         }
@@ -110,7 +110,7 @@ namespace clove {
                 case StoreOperation::DontCare:
                     return MTLStoreActionDontCare;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
                     return MTLStoreActionUnknown;
             }
         }
@@ -122,7 +122,7 @@ namespace clove {
                 case GhaSampler::Filter::Linear:
                     return MTLSamplerMinMagFilterLinear;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown filter", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown filter", CLOVE_FUNCTION_NAME);
                     return MTLSamplerMinMagFilterNearest;
             }
         }
@@ -138,7 +138,7 @@ namespace clove {
                 case GhaSampler::AddressMode::ClampToBorder:
                     return MTLSamplerAddressModeClampToBorderColor;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown address mode", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown address mode", CLOVE_FUNCTION_NAME);
                     return MTLSamplerAddressModeRepeat;
             }
         }

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsCommandBuffer.mm
@@ -20,7 +20,7 @@ namespace clove {
                 case IndexType::Uint16:
                     return MTLIndexTypeUInt16;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown index type", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown index type", CLOVE_FUNCTION_NAME);
                     return MTLIndexTypeUInt16;
             }
         }
@@ -196,7 +196,7 @@ namespace clove {
                                           atIndex:pushConstantSlot];
                         break;
                     default:
-                        CLOVE_ASSERT(false, "{0}: Unknown shader stage provided", CLOVE_FUNCTION_NAME_PRETTY);
+                        CLOVE_ASSERT_MSG(false, "{0}: Unknown shader stage provided", CLOVE_FUNCTION_NAME_PRETTY);
                         break;
                 }
             }

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsCommandBuffer.mm
@@ -99,7 +99,7 @@ namespace clove {
         currentPass->commands.emplace_back([pipelineObject = &pipelineObject](id<MTLRenderCommandEncoder> encoder){
             auto const *const metalPipeline{ polyCast<MetalGraphicsPipelineObject const>(pipelineObject) };
             if(metalPipeline == nullptr){
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: PipelineObject is nullptr", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(Clove, LogLevel::Error, "{0}: PipelineObject is nullptr", CLOVE_FUNCTION_NAME);
                 return;
             }
             
@@ -129,7 +129,7 @@ namespace clove {
         currentPass->commands.emplace_back([descriptorSet = &descriptorSet, setNum](id<MTLRenderCommandEncoder> encoder){
             auto const *const metalDescriptorSet{ polyCast<MetalDescriptorSet>(descriptorSet) };
             if(metalDescriptorSet == nullptr){
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: DescriptorSet is nullptr", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(Clove, LogLevel::Error, "{0}: DescriptorSet is nullptr", CLOVE_FUNCTION_NAME);
                 return;
             }
             

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsCommandBuffer.mm
@@ -9,6 +9,7 @@
 #include "Clove/Graphics/Metal/MetalDescriptorSet.hpp"
 #include "Clove/Graphics/Metal/MetalDescriptorSetLayout.hpp"
 #include "Clove/Graphics/Metal/MetalPipelineObject.hpp"
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 #include <Clove/Cast.hpp>
 
@@ -99,7 +100,7 @@ namespace clove {
         currentPass->commands.emplace_back([pipelineObject = &pipelineObject](id<MTLRenderCommandEncoder> encoder){
             auto const *const metalPipeline{ polyCast<MetalGraphicsPipelineObject const>(pipelineObject) };
             if(metalPipeline == nullptr){
-                CLOVE_LOG(Clove, LogLevel::Error, "{0}: PipelineObject is nullptr", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: PipelineObject is nullptr", CLOVE_FUNCTION_NAME);
                 return;
             }
             
@@ -129,7 +130,7 @@ namespace clove {
         currentPass->commands.emplace_back([descriptorSet = &descriptorSet, setNum](id<MTLRenderCommandEncoder> encoder){
             auto const *const metalDescriptorSet{ polyCast<MetalDescriptorSet>(descriptorSet) };
             if(metalDescriptorSet == nullptr){
-                CLOVE_LOG(Clove, LogLevel::Error, "{0}: DescriptorSet is nullptr", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: DescriptorSet is nullptr", CLOVE_FUNCTION_NAME);
                 return;
             }
             

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
@@ -6,6 +6,7 @@
 #include "Clove/Graphics/Metal/MetalFence.hpp"
 #include "Clove/Graphics/Metal/MetalPipelineObject.hpp"
 #include "Clove/Graphics/Metal/MetalSemaphore.hpp"
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 #include <Clove/Cast.hpp>
 
@@ -40,7 +41,7 @@ namespace clove {
                 
                 auto *metalCommandBuffer{ polyCast<MetalGraphicsCommandBuffer>(commandBuffer) };
                 if(metalCommandBuffer == nullptr) {
-                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                     continue;
                 }
                
@@ -53,7 +54,7 @@ namespace clove {
                     for (auto const &semaphore : submission.waitSemaphores) {
                         auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                         if(metalSemaphore == nullptr) {
-                            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                            CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                             continue;
                         }
                         

--- a/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalGraphicsQueue.mm
@@ -40,7 +40,7 @@ namespace clove {
                 
                 auto *metalCommandBuffer{ polyCast<MetalGraphicsCommandBuffer>(commandBuffer) };
                 if(metalCommandBuffer == nullptr) {
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                     continue;
                 }
                
@@ -53,7 +53,7 @@ namespace clove {
                     for (auto const &semaphore : submission.waitSemaphores) {
                         auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                         if(metalSemaphore == nullptr) {
-                            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                             continue;
                         }
                         

--- a/clove/components/core/graphics/source/Metal/MetalImage.mm
+++ b/clove/components/core/graphics/source/Metal/MetalImage.mm
@@ -23,7 +23,7 @@ namespace clove {
                         return MTLTextureTypeCube;
                     }
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown type passed", CLOVE_FUNCTION_NAME_PRETTY);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown type passed", CLOVE_FUNCTION_NAME_PRETTY);
                     return MTLTextureType2D;
             }
         }
@@ -77,7 +77,7 @@ namespace clove {
             case Format::D32_SFLOAT:
                 return MTLPixelFormatDepth32Float;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown format", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown format", CLOVE_FUNCTION_NAME);
                 return MTLPixelFormatInvalid;
         }
     }
@@ -97,7 +97,7 @@ namespace clove {
             case MTLPixelFormatDepth32Float:
                 return Format::D32_SFLOAT;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown format", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown format", CLOVE_FUNCTION_NAME);
                 return Format::Unkown;
         }
     }

--- a/clove/components/core/graphics/source/Metal/MetalPipelineObject.mm
+++ b/clove/components/core/graphics/source/Metal/MetalPipelineObject.mm
@@ -15,7 +15,7 @@ namespace clove {
 			case PipelineStage::ColourAttachmentOutput:
 				return MTLRenderStageFragment;
 			default:
-				CLOVE_ASSERT(false, "{0}: Provided stage does not convert properly", CLOVE_FUNCTION_NAME_PRETTY);
+				CLOVE_ASSERT_MSG(false, "{0}: Provided stage does not convert properly", CLOVE_FUNCTION_NAME_PRETTY);
 				return MTLRenderStageFragment;
 		}
 	}

--- a/clove/components/core/graphics/source/Metal/MetalSwapchain.mm
+++ b/clove/components/core/graphics/source/Metal/MetalSwapchain.mm
@@ -2,8 +2,7 @@
 
 #include "Clove/Graphics/Metal/MetalImage.hpp"
 #include "Clove/Graphics/Metal/MetalImageView.hpp"
-
-#include <Clove/Log/Log.hpp>
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 namespace clove {
 	MetalSwapchain::MetalSwapchain(std::vector<std::unique_ptr<GhaImage>> images, GhaImage::Format imageFormat, vec2ui imageSize)
@@ -33,7 +32,7 @@ namespace clove {
 		//TODO: Handle resizing;
 		
 		if(imageQueue.empty()) {
-			CLOVE_LOG(Clove, LogLevel::Error, "{0} has no available images", CLOVE_FUNCTION_NAME_PRETTY);
+			CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0} has no available images", CLOVE_FUNCTION_NAME_PRETTY);
 			return { -1, Result::Unkown };
 		}
 		

--- a/clove/components/core/graphics/source/Metal/MetalSwapchain.mm
+++ b/clove/components/core/graphics/source/Metal/MetalSwapchain.mm
@@ -33,7 +33,7 @@ namespace clove {
 		//TODO: Handle resizing;
 		
 		if(imageQueue.empty()) {
-			CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0} has no available images", CLOVE_FUNCTION_NAME_PRETTY);
+			CLOVE_LOG(Clove, LogLevel::Error, "{0} has no available images", CLOVE_FUNCTION_NAME_PRETTY);
 			return { -1, Result::Unkown };
 		}
 		

--- a/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
@@ -55,7 +55,7 @@ namespace clove {
 		commands.emplace_back([source = &source, sourceOffset, destination = &destination, destinationOffset, destinationExtent](id<MTLBlitCommandEncoder> encoder){
 			auto const *const metalImage{ polyCast<MetalImage>(destination) };
             if(metalImage == nullptr){
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
                 return;
             }
             
@@ -77,7 +77,7 @@ namespace clove {
 		commands.emplace_back([source = &source, sourceOffset, sourceExtent, destination = &destination, destinationOffset](id<MTLBlitCommandEncoder> encoder){
 			auto const *const metalImage{ polyCast<MetalImage>(source) };
             if(metalImage == nullptr){
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
                 return;
             }
             

--- a/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
@@ -3,6 +3,7 @@
 #include "Clove/Graphics/Metal/MetalBuffer.hpp"
 #include "Clove/Graphics/Metal/MetalImage.hpp"
 #include "Clove/Graphics/Metal/MetalPipelineObject.hpp"
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 #include <Clove/Cast.hpp>
 

--- a/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
@@ -19,7 +19,7 @@ namespace clove {
 					return 4;
 				case GhaImage::Format::Unkown:
 				default:
-					CLOVE_ASSERT(false, "Unknown format type");
+					CLOVE_ASSERT_MSG(false, "Unknown format type");
 					return 0;
 			}
 		}

--- a/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
@@ -39,7 +39,7 @@ namespace clove {
                 
                 auto *metalCommandBuffer{ polyCast<MetalTransferCommandBuffer>(commandBuffer) };
                 if(metalCommandBuffer == nullptr) {
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                     continue;
                 }
                 
@@ -50,7 +50,7 @@ namespace clove {
                 for (auto const &semaphore : submission.waitSemaphores) {
                     auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                     if(metalSemaphore == nullptr) {
-                        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                        CLOVE_LOG(Clove, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
                     }
                     

--- a/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferQueue.mm
@@ -5,6 +5,7 @@
 #include "Clove/Graphics/Metal/MetalTransferCommandBuffer.hpp"
 #include "Clove/Graphics/Metal/MetalSemaphore.hpp"
 #include "Clove/Graphics/Metal/MetalFence.hpp"
+#include "Clove/Graphics/Metal/MetalLog.hpp"
 
 #include <Clove/Cast.hpp>
 
@@ -39,7 +40,7 @@ namespace clove {
                 
                 auto *metalCommandBuffer{ polyCast<MetalTransferCommandBuffer>(commandBuffer) };
                 if(metalCommandBuffer == nullptr) {
-                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
+                    CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Command buffer provided is nullptr", CLOVE_FUNCTION_NAME);
                     continue;
                 }
                 
@@ -50,7 +51,7 @@ namespace clove {
                 for (auto const &semaphore : submission.waitSemaphores) {
                     auto const *const metalSemaphore{ polyCast<MetalSemaphore const>(semaphore.first) };
                     if(metalSemaphore == nullptr) {
-                        CLOVE_LOG(Clove, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
+                        CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Semaphore provided is nullptr", CLOVE_FUNCTION_NAME);
                         continue;
                     }
                     

--- a/clove/components/core/graphics/source/ShaderCompiler.cpp
+++ b/clove/components/core/graphics/source/ShaderCompiler.cpp
@@ -77,7 +77,7 @@ namespace clove::ShaderCompiler {
                 case GhaShader::Stage::Compute:
                     return shaderc_compute_shader;
                 default:
-                    CLOVE_ASSERT(false, "Unsupported shader stage {0}", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "Unsupported shader stage {0}", CLOVE_FUNCTION_NAME);
                     return shaderc_vertex_shader;
             }
         }

--- a/clove/components/core/graphics/source/ShaderCompiler.cpp
+++ b/clove/components/core/graphics/source/ShaderCompiler.cpp
@@ -50,7 +50,7 @@ namespace clove::ShaderCompiler {
                     result->content            = source.c_str();
                     result->content_length     = source.length();
                 } else {
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Requested source {1} was not found.", CLOVE_FUNCTION_NAME_PRETTY, requested_source);
+                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Requested source {1} was not found.", CLOVE_FUNCTION_NAME_PRETTY, requested_source);
 
                     std::string error{ "Source not available in map" };
 
@@ -85,7 +85,7 @@ namespace clove::ShaderCompiler {
             std::ifstream file(filePath.c_str(), std::ios::ate | std::ios::binary);
 
             if(!file.is_open()) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Failed to open file", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(Clove, LogLevel::Error, "{0}: Failed to open file", CLOVE_FUNCTION_NAME);
                 return {};
             }
 
@@ -101,7 +101,7 @@ namespace clove::ShaderCompiler {
         }
 
         Expected<std::vector<uint32_t>, std::runtime_error> compile(std::string_view source, std::unique_ptr<shaderc::CompileOptions::IncluderInterface> includer, std::string_view shaderName, GhaShader::Stage shaderStage) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Compiling shader {0}...", shaderName);
+            CLOVE_LOG(Clove, LogLevel::Trace, "Compiling shader {0}...", shaderName);
 
             shaderc::CompileOptions options{};
             options.SetIncluder(std::move(includer));
@@ -115,11 +115,11 @@ namespace clove::ShaderCompiler {
             shaderc::SpvCompilationResult spirvResult{ compiler.CompileGlslToSpv(source.data(), source.size(), getShadercStage(shaderStage), shaderName.data(), options) };
 
             if(spirvResult.GetCompilationStatus() != shaderc_compilation_status_success) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to compile shader {0}:\n\t{1}", shaderName, spirvResult.GetErrorMessage());
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to compile shader {0}:\n\t{1}", shaderName, spirvResult.GetErrorMessage());
                 return Unexpected{ std::runtime_error{ "Failed to compile shader. See output log for details." } };
             }
 
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Debug, "Successfully compiled shader {0}!", shaderName);
+            CLOVE_LOG(Clove, LogLevel::Debug, "Successfully compiled shader {0}!", shaderName);
             return std::vector<uint32_t>{ spirvResult.begin(), spirvResult.end() };
         }
     }

--- a/clove/components/core/graphics/source/ShaderCompiler.cpp
+++ b/clove/components/core/graphics/source/ShaderCompiler.cpp
@@ -14,6 +14,8 @@
 #include <spirv_msl.hpp>
 #include <sstream>
 
+CLOVE_DECLARE_LOG_CATEGORY(CloveShaderCompiler)
+
 namespace clove::ShaderCompiler {
     namespace {
         /**
@@ -50,7 +52,7 @@ namespace clove::ShaderCompiler {
                     result->content            = source.c_str();
                     result->content_length     = source.length();
                 } else {
-                    CLOVE_LOG(Clove, LogLevel::Error, "{0}: Requested source {1} was not found.", CLOVE_FUNCTION_NAME_PRETTY, requested_source);
+                    CLOVE_LOG(CloveShaderCompiler, LogLevel::Error, "{0}: Requested source {1} was not found.", CLOVE_FUNCTION_NAME_PRETTY, requested_source);
 
                     std::string error{ "Source not available in map" };
 
@@ -75,7 +77,7 @@ namespace clove::ShaderCompiler {
                 case GhaShader::Stage::Compute:
                     return shaderc_compute_shader;
                 default:
-                    CLOVE_ASSERT("Unsupported shader stage {0}", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT(false, "Unsupported shader stage {0}", CLOVE_FUNCTION_NAME);
                     return shaderc_vertex_shader;
             }
         }
@@ -85,7 +87,7 @@ namespace clove::ShaderCompiler {
             std::ifstream file(filePath.c_str(), std::ios::ate | std::ios::binary);
 
             if(!file.is_open()) {
-                CLOVE_LOG(Clove, LogLevel::Error, "{0}: Failed to open file", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveShaderCompiler, LogLevel::Error, "{0}: Failed to open file", CLOVE_FUNCTION_NAME);
                 return {};
             }
 
@@ -101,7 +103,7 @@ namespace clove::ShaderCompiler {
         }
 
         Expected<std::vector<uint32_t>, std::runtime_error> compile(std::string_view source, std::unique_ptr<shaderc::CompileOptions::IncluderInterface> includer, std::string_view shaderName, GhaShader::Stage shaderStage) {
-            CLOVE_LOG(Clove, LogLevel::Trace, "Compiling shader {0}...", shaderName);
+            CLOVE_LOG(CloveShaderCompiler, LogLevel::Trace, "Compiling shader {0}...", shaderName);
 
             shaderc::CompileOptions options{};
             options.SetIncluder(std::move(includer));
@@ -115,11 +117,11 @@ namespace clove::ShaderCompiler {
             shaderc::SpvCompilationResult spirvResult{ compiler.CompileGlslToSpv(source.data(), source.size(), getShadercStage(shaderStage), shaderName.data(), options) };
 
             if(spirvResult.GetCompilationStatus() != shaderc_compilation_status_success) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to compile shader {0}:\n\t{1}", shaderName, spirvResult.GetErrorMessage());
+                CLOVE_LOG(CloveShaderCompiler, LogLevel::Error, "Failed to compile shader {0}:\n\t{1}", shaderName, spirvResult.GetErrorMessage());
                 return Unexpected{ std::runtime_error{ "Failed to compile shader. See output log for details." } };
             }
 
-            CLOVE_LOG(Clove, LogLevel::Debug, "Successfully compiled shader {0}!", shaderName);
+            CLOVE_LOG(CloveShaderCompiler, LogLevel::Debug, "Successfully compiled shader {0}!", shaderName);
             return std::vector<uint32_t>{ spirvResult.begin(), spirvResult.end() };
         }
     }

--- a/clove/components/core/graphics/source/Validation/ValidationCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Validation/ValidationCommandBuffer.cpp
@@ -20,10 +20,10 @@ namespace clove {
     }
 
     void ValidationCommandBuffer::validateBeginRecording() {
-        CLOVE_ASSERT(endRecordingCalled, "beginRecording called before endRecording. Command buffer recording must be finished be starting again.");
+        CLOVE_ASSERT_MSG(endRecordingCalled, "beginRecording called before endRecording. Command buffer recording must be finished be starting again.");
         endRecordingCalled = false;
-        
-        CLOVE_ASSERT(!(!allowReuse && hasBeenUsed), "Command buffer re-recorded to. Command buffers cannot be recorded to more than once unless the owning queue has been created with QueueFlags::ReuseBuffers set.");
+
+        CLOVE_ASSERT_MSG(!(!allowReuse && hasBeenUsed), "Command buffer re-recorded to. Command buffers cannot be recorded to more than once unless the owning queue has been created with QueueFlags::ReuseBuffers set.");
     }
 
     void ValidationCommandBuffer::resetUsedFlag() {

--- a/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
+++ b/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
@@ -15,7 +15,7 @@ namespace clove {
                 }
             }
 
-            CLOVE_ASSERT(false, "{0}: Failed to find the specified index", CLOVE_FUNCTION_NAME);
+            CLOVE_ASSERT_MSG(false, "{0}: Failed to find the specified index", CLOVE_FUNCTION_NAME);
             return -1;
         }
     }
@@ -161,7 +161,7 @@ namespace clove {
             VkDeviceSize const size{ std::max(memoryRequirements.size, blockSize) };
             memoryBlocks.emplace_back(device.get(), size, memoryTypeIndex);
             freeChunk = memoryBlocks.back().allocate(memoryRequirements.size, memoryRequirements.alignment);
-            CLOVE_ASSERT(freeChunk != nullptr, "{0}: Newly allocated Block does not have enough room", CLOVE_FUNCTION_NAME_PRETTY);
+            CLOVE_ASSERT_MSG(freeChunk != nullptr, "{0}: Newly allocated Block does not have enough room", CLOVE_FUNCTION_NAME_PRETTY);
         }
 
         return freeChunk;

--- a/clove/components/core/graphics/source/Vulkan/VulkanCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanCommandBuffer.cpp
@@ -16,7 +16,7 @@ namespace clove {
             case clove::CommandBufferUsage::OneTimeSubmit:
                 return VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown usage type", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown usage type", CLOVE_FUNCTION_NAME);
                 return 0;
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
@@ -2,12 +2,12 @@
 
 #include "Clove/Graphics/Vulkan/VulkanBuffer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanCommandBuffer.hpp"
-#include "Clove/Graphics/Vulkan/VulkanImage.hpp"
-#include "Clove/Graphics/Vulkan/VulkanDescriptorSet.hpp"
 #include "Clove/Graphics/Vulkan/VulkanComputePipelineObject.hpp"
+#include "Clove/Graphics/Vulkan/VulkanDescriptorSet.hpp"
+#include "Clove/Graphics/Vulkan/VulkanImage.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 #include <Clove/Cast.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     VulkanComputeCommandBuffer::VulkanComputeCommandBuffer(VkCommandBuffer commandBuffer, QueueFamilyIndices queueFamilyIndices)
@@ -29,13 +29,13 @@ namespace clove {
         };
 
         if(vkBeginCommandBuffer(commandBuffer, &beginInfo) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to begin recording command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to begin recording command buffer");
         }
     }
 
     void VulkanComputeCommandBuffer::endRecording() {
         if(vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to end recording command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to end recording command buffer");
         }
     }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
@@ -29,13 +29,13 @@ namespace clove {
         };
 
         if(vkBeginCommandBuffer(commandBuffer, &beginInfo) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to begin recording command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to begin recording command buffer");
         }
     }
 
     void VulkanComputeCommandBuffer::endRecording() {
         if(vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to end recording command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to end recording command buffer");
         }
     }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
@@ -5,10 +5,10 @@
 #include "Clove/Graphics/Vulkan/VulkanFence.hpp"
 #include "Clove/Graphics/Vulkan/VulkanPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSemaphore.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 #include <Clove/Cast.hpp>
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     VulkanComputeQueue::VulkanComputeQueue(CommandQueueDescriptor descriptor, DevicePointer device, VkQueue queue, VkCommandPool commandPool, QueueFamilyIndices queueFamilyIndices)
@@ -42,7 +42,7 @@ namespace clove {
         };
 
         if(vkAllocateCommandBuffers(device.get(), &allocInfo, &commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to allocate command buffer");
             return nullptr;
         }
 
@@ -100,7 +100,7 @@ namespace clove {
 
         uint32_t constexpr submitCount{ 1 };
         if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to submit compute command buffer(s)");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to submit compute command buffer(s)");
         }
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeQueue.cpp
@@ -42,7 +42,7 @@ namespace clove {
         };
 
         if(vkAllocateCommandBuffers(device.get(), &allocInfo, &commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to allocate command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate command buffer");
             return nullptr;
         }
 
@@ -100,7 +100,7 @@ namespace clove {
 
         uint32_t constexpr submitCount{ 1 };
         if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to submit compute command buffer(s)");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to submit compute command buffer(s)");
         }
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanDescriptor.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDescriptor.cpp
@@ -14,7 +14,7 @@ namespace clove {
             case DescriptorType::Sampler:
                 return VK_DESCRIPTOR_TYPE_SAMPLER;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown type", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown type", CLOVE_FUNCTION_NAME);
                 return VK_DESCRIPTOR_TYPE_MAX_ENUM;
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanDescriptorPool.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDescriptorPool.cpp
@@ -2,9 +2,9 @@
 
 #include "Clove/Graphics/Vulkan/VulkanDescriptorSet.hpp"
 #include "Clove/Graphics/Vulkan/VulkanDescriptorSetLayout.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 #include <Clove/Cast.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     VulkanDescriptorPool::VulkanDescriptorPool(DevicePointer device, VkDescriptorPool pool, Descriptor descriptor)
@@ -44,7 +44,7 @@ namespace clove {
         };
 
         if(vkAllocateDescriptorSets(device.get(), &allocInfo, std::data(vulkanSets)) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate new descriptor sets");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to allocate new descriptor sets");
             return {};
         }
 
@@ -69,7 +69,7 @@ namespace clove {
         }
 
         if(vkFreeDescriptorSets(device.get(), pool, numSets, std::data(vulkanSets)) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to free descriptor sets");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to free descriptor sets");
         }
     }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanDescriptorPool.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDescriptorPool.cpp
@@ -44,7 +44,7 @@ namespace clove {
         };
 
         if(vkAllocateDescriptorSets(device.get(), &allocInfo, std::data(vulkanSets)) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to allocate new descriptor sets");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate new descriptor sets");
             return {};
         }
 
@@ -69,7 +69,7 @@ namespace clove {
         }
 
         if(vkFreeDescriptorSets(device.get(), pool, numSets, std::data(vulkanSets)) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to free descriptor sets");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to free descriptor sets");
         }
     }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -18,13 +18,13 @@
 
 #include "Clove/Graphics/Vulkan/VulkanDevice.hpp"
 #include "Clove/Graphics/Vulkan/VulkanFactory.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 #include <set>
 #include <unordered_set>
 
-CLOVE_DECLARE_LOG_CATEGORY(VulkanApi)
+CLOVE_DECLARE_LOG_CATEGORY(Vulkan)
 
 static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
     VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
@@ -32,11 +32,11 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
     VkDebugUtilsMessengerCallbackDataEXT const *pCallbackData,
     void *pUserData) {
     if((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) != 0) {
-        CLOVE_LOG(VulkanApi, clove::LogLevel::Trace, pCallbackData->pMessage);
+        CLOVE_LOG(Vulkan, clove::LogLevel::Trace, pCallbackData->pMessage);
     } else if((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0) {
-        CLOVE_LOG(VulkanApi, clove::LogLevel::Warning, pCallbackData->pMessage);
+        CLOVE_LOG(Vulkan, clove::LogLevel::Warning, pCallbackData->pMessage);
     } else if((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0) {
-        CLOVE_LOG(VulkanApi, clove::LogLevel::Error, pCallbackData->pMessage);
+        CLOVE_LOG(Vulkan, clove::LogLevel::Error, pCallbackData->pMessage);
     }
 
     return VK_FALSE;
@@ -79,7 +79,7 @@ namespace clove {
         }
 
         QueueFamilyIndices findQueueFamilies(VkPhysicalDevice device, VkSurfaceKHR surface) {
-            CLOVE_LOG(Clove, LogLevel::Trace, "Generating queue family indicies...");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "Generating queue family indicies...");
 
             QueueFamilyIndices indices{};
             std::set<size_t> graphicsFamilyIndices{};
@@ -90,7 +90,7 @@ namespace clove {
             uint32_t queueFamilyCount{ 0 };
             vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
 
-            CLOVE_LOG(Clove, LogLevel::Trace, "{0} queue families available", queueFamilyCount);
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "{0} queue families available", queueFamilyCount);
 
             std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
             vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
@@ -119,10 +119,10 @@ namespace clove {
             }
 
             if((presentFamilyIndices.empty() && surface != VK_NULL_HANDLE) || graphicsFamilyIndices.empty() || transferFamilyIndices.empty() || computeFamilyIndices.empty()) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Some queue types are unsupported. {0} failed.", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Some queue types are unsupported. {0} failed.", CLOVE_FUNCTION_NAME);
             }
 
-            CLOVE_LOG(Clove, LogLevel::Trace, "Distributing family types. Aiming for a unique family per queue type...");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "Distributing family types. Aiming for a unique family per queue type...");
             //Just taking the first one available for now. Not forcing the present queue to be unique for now.
             //TODO: Should just make graphics and present the same one?
             if(surface != VK_NULL_HANDLE) {
@@ -144,13 +144,13 @@ namespace clove {
 
             indices.computeFamily = *computeFamilyIndices.begin();
 
-            CLOVE_LOG(Clove, LogLevel::Debug, "Vulkan queue types successfully distributed!");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Debug, "Vulkan queue types successfully distributed!");
             if(surface != VK_NULL_HANDLE) {
-                CLOVE_LOG(Clove, LogLevel::Trace, "\tPresent:\tid: {0}, count: {1}", *indices.presentFamily, queueFamilies[*indices.presentFamily].queueCount);
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "\tPresent:\tid: {0}, count: {1}", *indices.presentFamily, queueFamilies[*indices.presentFamily].queueCount);
             }
-            CLOVE_LOG(Clove, LogLevel::Trace, "\tGraphics:\tid: {0}, count: {1}", *indices.graphicsFamily, queueFamilies[*indices.graphicsFamily].queueCount);
-            CLOVE_LOG(Clove, LogLevel::Trace, "\tTransfer:\tid: {0}, count: {1}", *indices.transferFamily, queueFamilies[*indices.transferFamily].queueCount);
-            CLOVE_LOG(Clove, LogLevel::Trace, "\tCompute:\tid: {0}, count: {1}", *indices.computeFamily, queueFamilies[*indices.computeFamily].queueCount);
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "\tGraphics:\tid: {0}, count: {1}", *indices.graphicsFamily, queueFamilies[*indices.graphicsFamily].queueCount);
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "\tTransfer:\tid: {0}, count: {1}", *indices.transferFamily, queueFamilies[*indices.transferFamily].queueCount);
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "\tCompute:\tid: {0}, count: {1}", *indices.computeFamily, queueFamilies[*indices.computeFamily].queueCount);
 
             return indices;
         }
@@ -232,7 +232,7 @@ namespace clove {
         };
 
         if(!checkValidationLayerSupport(validationLayers)) {
-            CLOVE_LOG(Clove, LogLevel::Warning, "Vulkan validation layers are not supported on this device. Unable to provide debugging infomation");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Warning, "Vulkan validation layers are not supported on this device. Unable to provide debugging infomation");
         }
 #endif
 
@@ -277,13 +277,13 @@ namespace clove {
             };
 
             if(vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create VK instance");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to create VK instance");
                 return;
             }
 
 #if CLOVE_GHA_VALIDATION
             if(createDebugUtilsMessengerEXT(instance, &debugMessengerCreateInfo, nullptr, &debugMessenger) != VK_SUCCESS) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create vk debug message callback");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to create vk debug message callback");
                 return;
             }
 #endif
@@ -300,7 +300,7 @@ namespace clove {
             };
 
             if(vkCreateWin32SurfaceKHR(instance, &createInfo, nullptr, &surface) != VK_SUCCESS) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create Vulkan surface");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to create Vulkan surface");
                 return;
             }
 #elif CLOVE_PLATFORM_MACOS
@@ -315,7 +315,7 @@ namespace clove {
             };
 
             if(vkCreateXlibSurfaceKHR(instance, &createInfo, nullptr, &surface) != VK_SUCCESS) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create Vulkan surface");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to create Vulkan surface");
                 return;
             }
 #endif
@@ -324,22 +324,22 @@ namespace clove {
         //Pick physical device
         VkPhysicalDevice physicalDevice{ VK_NULL_HANDLE };
         {
-            CLOVE_LOG(Clove, LogLevel::Trace, "Searching for a suitable physical device...");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "Searching for a suitable physical device...");
 
             uint32_t deviceCount{ 0 };
             vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
             if(deviceCount == 0) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to find GPUs with Vulkan support!");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to find GPUs with Vulkan support!");
                 return;
             }
             std::vector<VkPhysicalDevice> devices(deviceCount);
             vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
 
-            CLOVE_LOG(Clove, LogLevel::Trace, "Found {0} potential devices:", deviceCount);
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "Found {0} potential devices:", deviceCount);
             for(auto const &device : devices) {
                 VkPhysicalDeviceProperties devicePoperties{};
                 vkGetPhysicalDeviceProperties(device, &devicePoperties);
-                CLOVE_LOG(Clove, LogLevel::Trace, "\t{0}", devicePoperties.deviceName);
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "\t{0}", devicePoperties.deviceName);
             }
 
             for(auto const &device : devices) {
@@ -350,16 +350,16 @@ namespace clove {
             }
 
             if(physicalDevice == VK_NULL_HANDLE) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to find a suitable GPU!");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to find a suitable GPU!");
                 return;
             } else {
                 VkPhysicalDeviceProperties devicePoperties;
                 vkGetPhysicalDeviceProperties(physicalDevice, &devicePoperties);
 
-                CLOVE_LOG(Clove, LogLevel::Info, "Vulkan capable physical device found");
-                CLOVE_LOG(Clove, LogLevel::Info, "\tDevice:\t{0}", devicePoperties.deviceName);
-                CLOVE_LOG(Clove, LogLevel::Info, "\tDriver:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.driverVersion), VK_VERSION_MINOR(devicePoperties.driverVersion), VK_VERSION_PATCH(devicePoperties.driverVersion));
-                CLOVE_LOG(Clove, LogLevel::Info, "\tAPI:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.apiVersion), VK_VERSION_MINOR(devicePoperties.apiVersion), VK_VERSION_PATCH(devicePoperties.apiVersion));
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "Vulkan capable physical device found");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "\tDevice:\t{0}", devicePoperties.deviceName);
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "\tDriver:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.driverVersion), VK_VERSION_MINOR(devicePoperties.driverVersion), VK_VERSION_PATCH(devicePoperties.driverVersion));
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "\tAPI:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.apiVersion), VK_VERSION_MINOR(devicePoperties.apiVersion), VK_VERSION_PATCH(devicePoperties.apiVersion));
             }
         }
 
@@ -413,7 +413,7 @@ namespace clove {
             };
 
             if(vkCreateDevice(physicalDevice, &createInfo, nullptr, &logicalDevice) != VK_SUCCESS) {
-                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create logical device");
+                CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to create logical device");
                 return;
             }
         }
@@ -436,16 +436,16 @@ namespace clove {
         if(VkResult const result{ vkDeviceWaitIdle(devicePtr.get()) }; result != VK_SUCCESS) {
             switch(result) {
                 case VK_ERROR_OUT_OF_HOST_MEMORY:
-                    CLOVE_LOG(Clove, LogLevel::Error, "Error while waiting for device. Out of host memory.");
+                    CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Error while waiting for device. Out of host memory.");
                     break;
                 case VK_ERROR_OUT_OF_DEVICE_MEMORY:
-                    CLOVE_LOG(Clove, LogLevel::Error, "Error while waiting for device. Out of device memory.");
+                    CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Error while waiting for device. Out of device memory.");
                     break;
                 case VK_ERROR_DEVICE_LOST:
-                    CLOVE_LOG(Clove, LogLevel::Error, "Error while waiting for device. Device lost.");
+                    CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Error while waiting for device. Device lost.");
                     break;
                 default:
-                    CLOVE_LOG(Clove, LogLevel::Error, "Unknown error while waiting for device.");
+                    CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Unknown error while waiting for device.");
                     break;
             }
         }

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -304,7 +304,7 @@ namespace clove {
                 return;
             }
 #elif CLOVE_PLATFORM_MACOS
-            CLOVE_ASSERT(false, "Vulkan implementation not provided on MacOS");
+            CLOVE_ASSERT_MSG(false, "Vulkan implementation not provided on MacOS");
 #elif CLOVE_PLATFORM_LINUX
             auto const [display, window] = std::any_cast<std::pair<Display *, ::Window>>(nativeWindow);
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -24,7 +24,7 @@
 #include <set>
 #include <unordered_set>
 
-CLOVE_DECLARE_LOG_CATEGORY(VULKAN)
+CLOVE_DECLARE_LOG_CATEGORY(VulkanApi)
 
 static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
     VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
@@ -32,11 +32,11 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
     VkDebugUtilsMessengerCallbackDataEXT const *pCallbackData,
     void *pUserData) {
     if((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) != 0) {
-        CLOVE_LOG(LOG_CATEGORY_VULKAN, clove::LogLevel::Trace, pCallbackData->pMessage);
+        CLOVE_LOG(VulkanApi, clove::LogLevel::Trace, pCallbackData->pMessage);
     } else if((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) != 0) {
-        CLOVE_LOG(LOG_CATEGORY_VULKAN, clove::LogLevel::Warning, pCallbackData->pMessage);
+        CLOVE_LOG(VulkanApi, clove::LogLevel::Warning, pCallbackData->pMessage);
     } else if((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) != 0) {
-        CLOVE_LOG(LOG_CATEGORY_VULKAN, clove::LogLevel::Error, pCallbackData->pMessage);
+        CLOVE_LOG(VulkanApi, clove::LogLevel::Error, pCallbackData->pMessage);
     }
 
     return VK_FALSE;
@@ -79,7 +79,7 @@ namespace clove {
         }
 
         QueueFamilyIndices findQueueFamilies(VkPhysicalDevice device, VkSurfaceKHR surface) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Generating queue family indicies...");
+            CLOVE_LOG(Clove, LogLevel::Trace, "Generating queue family indicies...");
 
             QueueFamilyIndices indices{};
             std::set<size_t> graphicsFamilyIndices{};
@@ -90,7 +90,7 @@ namespace clove {
             uint32_t queueFamilyCount{ 0 };
             vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, nullptr);
 
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "{0} queue families available", queueFamilyCount);
+            CLOVE_LOG(Clove, LogLevel::Trace, "{0} queue families available", queueFamilyCount);
 
             std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
             vkGetPhysicalDeviceQueueFamilyProperties(device, &queueFamilyCount, queueFamilies.data());
@@ -119,10 +119,10 @@ namespace clove {
             }
 
             if((presentFamilyIndices.empty() && surface != VK_NULL_HANDLE) || graphicsFamilyIndices.empty() || transferFamilyIndices.empty() || computeFamilyIndices.empty()) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Some queue types are unsupported. {0} failed.", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(Clove, LogLevel::Error, "Some queue types are unsupported. {0} failed.", CLOVE_FUNCTION_NAME);
             }
 
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Distributing family types. Aiming for a unique family per queue type...");
+            CLOVE_LOG(Clove, LogLevel::Trace, "Distributing family types. Aiming for a unique family per queue type...");
             //Just taking the first one available for now. Not forcing the present queue to be unique for now.
             //TODO: Should just make graphics and present the same one?
             if(surface != VK_NULL_HANDLE) {
@@ -144,13 +144,13 @@ namespace clove {
 
             indices.computeFamily = *computeFamilyIndices.begin();
 
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Debug, "Vulkan queue types successfully distributed!");
+            CLOVE_LOG(Clove, LogLevel::Debug, "Vulkan queue types successfully distributed!");
             if(surface != VK_NULL_HANDLE) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "\tPresent:\tid: {0}, count: {1}", *indices.presentFamily, queueFamilies[*indices.presentFamily].queueCount);
+                CLOVE_LOG(Clove, LogLevel::Trace, "\tPresent:\tid: {0}, count: {1}", *indices.presentFamily, queueFamilies[*indices.presentFamily].queueCount);
             }
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "\tGraphics:\tid: {0}, count: {1}", *indices.graphicsFamily, queueFamilies[*indices.graphicsFamily].queueCount);
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "\tTransfer:\tid: {0}, count: {1}", *indices.transferFamily, queueFamilies[*indices.transferFamily].queueCount);
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "\tCompute:\tid: {0}, count: {1}", *indices.computeFamily, queueFamilies[*indices.computeFamily].queueCount);
+            CLOVE_LOG(Clove, LogLevel::Trace, "\tGraphics:\tid: {0}, count: {1}", *indices.graphicsFamily, queueFamilies[*indices.graphicsFamily].queueCount);
+            CLOVE_LOG(Clove, LogLevel::Trace, "\tTransfer:\tid: {0}, count: {1}", *indices.transferFamily, queueFamilies[*indices.transferFamily].queueCount);
+            CLOVE_LOG(Clove, LogLevel::Trace, "\tCompute:\tid: {0}, count: {1}", *indices.computeFamily, queueFamilies[*indices.computeFamily].queueCount);
 
             return indices;
         }
@@ -232,7 +232,7 @@ namespace clove {
         };
 
         if(!checkValidationLayerSupport(validationLayers)) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "Vulkan validation layers are not supported on this device. Unable to provide debugging infomation");
+            CLOVE_LOG(Clove, LogLevel::Warning, "Vulkan validation layers are not supported on this device. Unable to provide debugging infomation");
         }
 #endif
 
@@ -277,13 +277,13 @@ namespace clove {
             };
 
             if(vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create VK instance");
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create VK instance");
                 return;
             }
 
 #if CLOVE_GHA_VALIDATION
             if(createDebugUtilsMessengerEXT(instance, &debugMessengerCreateInfo, nullptr, &debugMessenger) != VK_SUCCESS) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create vk debug message callback");
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create vk debug message callback");
                 return;
             }
 #endif
@@ -300,7 +300,7 @@ namespace clove {
             };
 
             if(vkCreateWin32SurfaceKHR(instance, &createInfo, nullptr, &surface) != VK_SUCCESS) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create Vulkan surface");
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create Vulkan surface");
                 return;
             }
 #elif CLOVE_PLATFORM_MACOS
@@ -324,22 +324,22 @@ namespace clove {
         //Pick physical device
         VkPhysicalDevice physicalDevice{ VK_NULL_HANDLE };
         {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Searching for a suitable physical device...");
+            CLOVE_LOG(Clove, LogLevel::Trace, "Searching for a suitable physical device...");
 
             uint32_t deviceCount{ 0 };
             vkEnumeratePhysicalDevices(instance, &deviceCount, nullptr);
             if(deviceCount == 0) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to find GPUs with Vulkan support!");
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to find GPUs with Vulkan support!");
                 return;
             }
             std::vector<VkPhysicalDevice> devices(deviceCount);
             vkEnumeratePhysicalDevices(instance, &deviceCount, devices.data());
 
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Found {0} potential devices:", deviceCount);
+            CLOVE_LOG(Clove, LogLevel::Trace, "Found {0} potential devices:", deviceCount);
             for(auto const &device : devices) {
                 VkPhysicalDeviceProperties devicePoperties{};
                 vkGetPhysicalDeviceProperties(device, &devicePoperties);
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "\t{0}", devicePoperties.deviceName);
+                CLOVE_LOG(Clove, LogLevel::Trace, "\t{0}", devicePoperties.deviceName);
             }
 
             for(auto const &device : devices) {
@@ -350,16 +350,16 @@ namespace clove {
             }
 
             if(physicalDevice == VK_NULL_HANDLE) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to find a suitable GPU!");
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to find a suitable GPU!");
                 return;
             } else {
                 VkPhysicalDeviceProperties devicePoperties;
                 vkGetPhysicalDeviceProperties(physicalDevice, &devicePoperties);
 
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Info, "Vulkan capable physical device found");
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Info, "\tDevice:\t{0}", devicePoperties.deviceName);
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Info, "\tDriver:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.driverVersion), VK_VERSION_MINOR(devicePoperties.driverVersion), VK_VERSION_PATCH(devicePoperties.driverVersion));
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Info, "\tAPI:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.apiVersion), VK_VERSION_MINOR(devicePoperties.apiVersion), VK_VERSION_PATCH(devicePoperties.apiVersion));
+                CLOVE_LOG(Clove, LogLevel::Info, "Vulkan capable physical device found");
+                CLOVE_LOG(Clove, LogLevel::Info, "\tDevice:\t{0}", devicePoperties.deviceName);
+                CLOVE_LOG(Clove, LogLevel::Info, "\tDriver:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.driverVersion), VK_VERSION_MINOR(devicePoperties.driverVersion), VK_VERSION_PATCH(devicePoperties.driverVersion));
+                CLOVE_LOG(Clove, LogLevel::Info, "\tAPI:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.apiVersion), VK_VERSION_MINOR(devicePoperties.apiVersion), VK_VERSION_PATCH(devicePoperties.apiVersion));
             }
         }
 
@@ -413,7 +413,7 @@ namespace clove {
             };
 
             if(vkCreateDevice(physicalDevice, &createInfo, nullptr, &logicalDevice) != VK_SUCCESS) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create logical device");
+                CLOVE_LOG(Clove, LogLevel::Error, "Failed to create logical device");
                 return;
             }
         }
@@ -436,16 +436,16 @@ namespace clove {
         if(VkResult const result{ vkDeviceWaitIdle(devicePtr.get()) }; result != VK_SUCCESS) {
             switch(result) {
                 case VK_ERROR_OUT_OF_HOST_MEMORY:
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Error while waiting for device. Out of host memory.");
+                    CLOVE_LOG(Clove, LogLevel::Error, "Error while waiting for device. Out of host memory.");
                     break;
                 case VK_ERROR_OUT_OF_DEVICE_MEMORY:
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Error while waiting for device. Out of device memory.");
+                    CLOVE_LOG(Clove, LogLevel::Error, "Error while waiting for device. Out of device memory.");
                     break;
                 case VK_ERROR_DEVICE_LOST:
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Error while waiting for device. Device lost.");
+                    CLOVE_LOG(Clove, LogLevel::Error, "Error while waiting for device. Device lost.");
                     break;
                 default:
-                    CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Unknown error while waiting for device.");
+                    CLOVE_LOG(Clove, LogLevel::Error, "Unknown error while waiting for device.");
                     break;
             }
         }

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -86,7 +86,7 @@ namespace clove {
                 case LoadOperation::DontCare:
                     return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
                     return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             }
         }
@@ -98,7 +98,7 @@ namespace clove {
                 case StoreOperation::DontCare:
                     return VK_ATTACHMENT_STORE_OP_DONT_CARE;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown operation", CLOVE_FUNCTION_NAME);
                     return VK_ATTACHMENT_STORE_OP_DONT_CARE;
             }
         }
@@ -116,7 +116,7 @@ namespace clove {
                 case VertexAttributeFormat::R32G32B32A32_SINT:
                     return VK_FORMAT_R32G32B32A32_SINT;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown format passed", CLOVE_FUNCTION_NAME_PRETTY);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown format passed", CLOVE_FUNCTION_NAME_PRETTY);
                     return VK_FORMAT_UNDEFINED;
             }
         }
@@ -128,7 +128,7 @@ namespace clove {
                 case GhaDescriptorPool::Flag::FreeDescriptorSet:
                     return VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
                 default:
-                    CLOVE_ASSERT(false, "{0} Unknown flag", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0} Unknown flag", CLOVE_FUNCTION_NAME);
             }
         }
 
@@ -187,7 +187,7 @@ namespace clove {
                 case GhaImage::Type::_3D:
                     return VK_IMAGE_TYPE_3D;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unhandled image type");
+                    CLOVE_ASSERT_MSG(false, "{0}: Unhandled image type");
                     return VK_IMAGE_TYPE_2D;
             }
         }
@@ -199,7 +199,7 @@ namespace clove {
                 case GhaSampler::Filter::Linear:
                     return VK_FILTER_LINEAR;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown type", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown type", CLOVE_FUNCTION_NAME);
                     return VK_FILTER_NEAREST;
             }
         }
@@ -215,7 +215,7 @@ namespace clove {
                 case GhaSampler::AddressMode::ClampToBorder:
                     return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown type", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown type", CLOVE_FUNCTION_NAME);
                     return VK_SAMPLER_ADDRESS_MODE_REPEAT;
             }
         }

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -52,7 +52,7 @@ namespace clove {
             }
 
             //Fall back to the first one if we can't find a surface format we want
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "GhaSwapchain could not find desired format. Using first available format from the surface");
+            CLOVE_LOG(Clove, LogLevel::Warning, "GhaSwapchain could not find desired format. Using first available format from the surface");
             return availableFormats[0];
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -24,9 +24,9 @@
 #include "Clove/Graphics/Vulkan/VulkanShader.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSwapchain.hpp"
 #include "Clove/Graphics/Vulkan/VulkanTransferQueue.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 #include <Clove/Cast.hpp>
-#include <Clove/Log/Log.hpp>
 #include <fstream>
 
 namespace clove {
@@ -52,7 +52,7 @@ namespace clove {
             }
 
             //Fall back to the first one if we can't find a surface format we want
-            CLOVE_LOG(Clove, LogLevel::Warning, "GhaSwapchain could not find desired format. Using first available format from the surface");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Warning, "GhaSwapchain could not find desired format. Using first available format from the surface");
             return availableFormats[0];
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
@@ -19,7 +19,7 @@ namespace clove {
                 case IndexType::Uint16:
                     return VK_INDEX_TYPE_UINT16;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unkown index type", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Unkown index type", CLOVE_FUNCTION_NAME);
                     return VK_INDEX_TYPE_UINT16;
             }
         }

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
@@ -48,13 +48,13 @@ namespace clove {
         };
 
         if(vkBeginCommandBuffer(commandBuffer, &beginInfo) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to begin recording command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to begin recording command buffer");
         }
     }
 
     void VulkanGraphicsCommandBuffer::endRecording() {
         if(vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to end recording command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to end recording command buffer");
         }
     }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
@@ -6,6 +6,7 @@
 #include "Clove/Graphics/Vulkan/VulkanFramebuffer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanGraphicsPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanImage.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 #include "Clove/Graphics/Vulkan/VulkanRenderPass.hpp"
 #include "Clove/Graphics/Vulkan/VulkanShader.hpp"
 
@@ -48,13 +49,13 @@ namespace clove {
         };
 
         if(vkBeginCommandBuffer(commandBuffer, &beginInfo) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to begin recording command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to begin recording command buffer");
         }
     }
 
     void VulkanGraphicsCommandBuffer::endRecording() {
         if(vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to end recording command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to end recording command buffer");
         }
     }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
@@ -43,7 +43,7 @@ namespace clove {
         };
 
         if(vkAllocateCommandBuffers(device.get(), &allocInfo, &commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to allocate command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate command buffer");
             return nullptr;
         }
 
@@ -101,7 +101,7 @@ namespace clove {
 
         uint32_t constexpr submitCount{ 1 };
         if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to submit graphics command buffer(s)");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to submit graphics command buffer(s)");
         }
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsQueue.cpp
@@ -4,12 +4,12 @@
 #include "Clove/Graphics/Vulkan/VulkanFence.hpp"
 #include "Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanGraphicsPipelineObject.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 #include "Clove/Graphics/Vulkan/VulkanPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSemaphore.hpp"
 
 #include <Clove/Cast.hpp>
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     VulkanGraphicsQueue::VulkanGraphicsQueue(CommandQueueDescriptor descriptor, DevicePointer device, VkQueue queue, VkCommandPool commandPool, QueueFamilyIndices queueFamilyIndices)
@@ -43,7 +43,7 @@ namespace clove {
         };
 
         if(vkAllocateCommandBuffers(device.get(), &allocInfo, &commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to allocate command buffer");
             return nullptr;
         }
 
@@ -101,7 +101,7 @@ namespace clove {
 
         uint32_t constexpr submitCount{ 1 };
         if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to submit graphics command buffer(s)");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to submit graphics command buffer(s)");
         }
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanImage.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanImage.cpp
@@ -28,7 +28,7 @@ namespace clove {
                     }
                 }
                 default:
-                    CLOVE_ASSERT(false, "{0}: Unhandled image type");
+                    CLOVE_ASSERT_MSG(false, "{0}: Unhandled image type");
                     return VK_IMAGE_VIEW_TYPE_2D;
             }
         }
@@ -78,7 +78,7 @@ namespace clove {
             case VK_FORMAT_D32_SFLOAT:
                 return Format::D32_SFLOAT;
             default:
-                CLOVE_ASSERT(false, "{0}: Format not supported by garlic", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Format not supported by garlic", CLOVE_FUNCTION_NAME);
                 return Format::Unkown;
         }
     }
@@ -98,7 +98,7 @@ namespace clove {
             case Format::D32_SFLOAT:
                 return VK_FORMAT_D32_SFLOAT;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown format", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown format", CLOVE_FUNCTION_NAME);
                 return VK_FORMAT_UNDEFINED;
         }
     }
@@ -124,7 +124,7 @@ namespace clove {
             case Layout::DepthStencilReadOnlyOptimal:
                 return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown image layout", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown image layout", CLOVE_FUNCTION_NAME);
                 return VK_IMAGE_LAYOUT_UNDEFINED;
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanImageView.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanImageView.cpp
@@ -1,6 +1,6 @@
 #include "Clove/Graphics/Vulkan/VulkanImageView.hpp"
 
-#include <Clove/Log/Log.hpp>
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 namespace clove {
     VulkanImageView::VulkanImageView(VkDevice device, VkImageView imageView)
@@ -41,7 +41,7 @@ namespace clove {
 
         VkImageView imageView{ nullptr };
         if(vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to create texture image view");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to create texture image view");
             return VK_NULL_HANDLE;
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanImageView.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanImageView.cpp
@@ -41,7 +41,7 @@ namespace clove {
 
         VkImageView imageView{ nullptr };
         if(vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to create texture image view");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to create texture image view");
             return VK_NULL_HANDLE;
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanMemoryBarrier.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanMemoryBarrier.cpp
@@ -16,7 +16,7 @@ namespace clove {
             case QueueType::Compute:
                 return *indices.computeFamily;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown queue type", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown queue type", CLOVE_FUNCTION_NAME);
                 return VK_QUEUE_FAMILY_IGNORED;
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanPipelineObject.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanPipelineObject.cpp
@@ -24,7 +24,7 @@ namespace clove {
             case PipelineStage::ColourAttachmentOutput:
                 return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
             default:
-                CLOVE_ASSERT(false, "{0}: Unkown pipeline stage", CLOVE_FUNCTION_NAME);
+                CLOVE_ASSERT_MSG(false, "{0}: Unkown pipeline stage", CLOVE_FUNCTION_NAME);
                 return VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanResource.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanResource.cpp
@@ -34,7 +34,7 @@ namespace clove {
         }
 
         if(total != static_cast<AccessFlagsType>(garlicAccess)) {
-            CLOVE_ASSERT(false, "{0}: Unhandled access type", CLOVE_FUNCTION_NAME);
+            CLOVE_ASSERT_MSG(false, "{0}: Unhandled access type", CLOVE_FUNCTION_NAME);
         }
 
         return flags;

--- a/clove/components/core/graphics/source/Vulkan/VulkanResult.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanResult.cpp
@@ -13,7 +13,7 @@ namespace clove {
             case VK_ERROR_OUT_OF_DATE_KHR:
                 return Result::Error_SwapchainOutOfDate;
             default:
-                CLOVE_ASSERT(false, "Unkown result type");
+                CLOVE_ASSERT_MSG(false, "Unkown result type");
                 return Result::Unkown;
         }
     }

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
@@ -4,10 +4,10 @@
 #include "Clove/Graphics/Vulkan/VulkanCommandBuffer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanGraphicsPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanImage.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 #include <Clove/Cast.hpp>
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     VulkanTransferCommandBuffer::VulkanTransferCommandBuffer(VkCommandBuffer commandBuffer, QueueFamilyIndices queueFamilyIndices)
@@ -29,13 +29,13 @@ namespace clove {
         };
 
         if(vkBeginCommandBuffer(commandBuffer, &beginInfo) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to begin recording command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to begin recording command buffer");
         }
     }
 
     void VulkanTransferCommandBuffer::endRecording() {
         if(vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to end recording command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to end recording command buffer");
         }
     }
 
@@ -97,7 +97,7 @@ namespace clove {
             barrierInfo.newImageLayout != GhaImage::Layout::DepthStencilReadOnlyOptimal;
 
         if(!isValidLayout) {
-            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Invalid newLayout. This command buffer cannot handle transfering images to the following layouts:\n\tImageLayout::ShaderReadOnlyOptimal\n\tImageLayout::ColourAttachmentOptimal\n\tImageLayout::DepthStencilAttachmentOptimal\n\tImageLayout::DepthStencilReadOnlyOptimal", CLOVE_FUNCTION_NAME);
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "{0}: Invalid newLayout. This command buffer cannot handle transfering images to the following layouts:\n\tImageLayout::ShaderReadOnlyOptimal\n\tImageLayout::ColourAttachmentOptimal\n\tImageLayout::DepthStencilAttachmentOptimal\n\tImageLayout::DepthStencilReadOnlyOptimal", CLOVE_FUNCTION_NAME);
             return;
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
@@ -29,13 +29,13 @@ namespace clove {
         };
 
         if(vkBeginCommandBuffer(commandBuffer, &beginInfo) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to begin recording command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to begin recording command buffer");
         }
     }
 
     void VulkanTransferCommandBuffer::endRecording() {
         if(vkEndCommandBuffer(commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to end recording command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to end recording command buffer");
         }
     }
 
@@ -97,7 +97,7 @@ namespace clove {
             barrierInfo.newImageLayout != GhaImage::Layout::DepthStencilReadOnlyOptimal;
 
         if(!isValidLayout) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Invalid newLayout. This command buffer cannot handle transfering images to the following layouts:\n\tImageLayout::ShaderReadOnlyOptimal\n\tImageLayout::ColourAttachmentOptimal\n\tImageLayout::DepthStencilAttachmentOptimal\n\tImageLayout::DepthStencilReadOnlyOptimal", CLOVE_FUNCTION_NAME);
+            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Invalid newLayout. This command buffer cannot handle transfering images to the following layouts:\n\tImageLayout::ShaderReadOnlyOptimal\n\tImageLayout::ColourAttachmentOptimal\n\tImageLayout::DepthStencilAttachmentOptimal\n\tImageLayout::DepthStencilReadOnlyOptimal", CLOVE_FUNCTION_NAME);
             return;
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
@@ -3,13 +3,13 @@
 #include "Clove/Graphics/Helpers.hpp"
 #include "Clove/Graphics/Vulkan/VulkanFence.hpp"
 #include "Clove/Graphics/Vulkan/VulkanGraphicsPipelineObject.hpp"
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 #include "Clove/Graphics/Vulkan/VulkanPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanSemaphore.hpp"
 #include "Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp"
 
 #include <Clove/Cast.hpp>
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     VulkanTransferQueue::VulkanTransferQueue(CommandQueueDescriptor descriptor, DevicePointer device, VkQueue queue, VkCommandPool commandPool, QueueFamilyIndices queueFamilyIndices)
@@ -45,7 +45,7 @@ namespace clove {
         };
 
         if(vkAllocateCommandBuffers(device.get(), &allocInfo, &commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate command buffer");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to allocate command buffer");
             return nullptr;
         }
 
@@ -103,7 +103,7 @@ namespace clove {
 
         uint32_t constexpr submitCount{ 1 };
         if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Failed to submit transfer command buffer(s)");
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to submit transfer command buffer(s)");
         }
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferQueue.cpp
@@ -45,7 +45,7 @@ namespace clove {
         };
 
         if(vkAllocateCommandBuffers(device.get(), &allocInfo, &commandBuffer) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to allocate command buffer");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to allocate command buffer");
             return nullptr;
         }
 
@@ -103,7 +103,7 @@ namespace clove {
 
         uint32_t constexpr submitCount{ 1 };
         if(vkQueueSubmit(queue, submitCount, &submitInfo, vkFence) != VK_SUCCESS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Failed to submit transfer command buffer(s)");
+            CLOVE_LOG(Clove, LogLevel::Error, "Failed to submit transfer command buffer(s)");
         }
     }
 }

--- a/clove/components/core/platform/source/Linux/LinuxWindow.cpp
+++ b/clove/components/core/platform/source/Linux/LinuxWindow.cpp
@@ -9,7 +9,7 @@ namespace clove {
     LinuxWindow::LinuxWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
         CLOVE_LOG(ClovePlatformLinux, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
-        CLOVE_ASSERT(window == 0, "Window already exists! Currently only a single window on linux is supported");
+        CLOVE_ASSERT_MSG(window == 0, "Window already exists! Currently only a single window on linux is supported");
 
         if(display == nullptr) {
             //Make the connection to the client, where to display the window

--- a/clove/components/core/platform/source/Linux/LinuxWindow.cpp
+++ b/clove/components/core/platform/source/Linux/LinuxWindow.cpp
@@ -3,10 +3,12 @@
 #include <Clove/Definitions.hpp>
 #include <Clove/Log/Log.hpp>
 
+CLOVE_DECLARE_LOG_CATEGORY(ClovePlatformLinux)
+
 namespace clove {
     LinuxWindow::LinuxWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(Clove, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
+        CLOVE_LOG(ClovePlatformLinux, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
         CLOVE_ASSERT(window == 0, "Window already exists! Currently only a single window on linux is supported");
 
         if(display == nullptr) {
@@ -16,7 +18,7 @@ namespace clove {
 
         if(display == nullptr) {
             //TODO: Exception
-            CLOVE_LOG(Clove, LogLevel::Error, "Could not open display");
+            CLOVE_LOG(ClovePlatformLinux, LogLevel::Error, "Could not open display");
             return;
         }
 
@@ -51,7 +53,7 @@ namespace clove {
 
         open = true;
 
-        CLOVE_LOG(Clove, LogLevel::Trace, "Window created");
+        CLOVE_LOG(ClovePlatformLinux, LogLevel::Trace, "Window created");
     }
 
     LinuxWindow::~LinuxWindow() {

--- a/clove/components/core/platform/source/Linux/LinuxWindow.cpp
+++ b/clove/components/core/platform/source/Linux/LinuxWindow.cpp
@@ -6,7 +6,7 @@
 namespace clove {
     LinuxWindow::LinuxWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
+        CLOVE_LOG(Clove, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
         CLOVE_ASSERT(window == 0, "Window already exists! Currently only a single window on linux is supported");
 
         if(display == nullptr) {
@@ -16,7 +16,7 @@ namespace clove {
 
         if(display == nullptr) {
             //TODO: Exception
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Could not open display");
+            CLOVE_LOG(Clove, LogLevel::Error, "Could not open display");
             return;
         }
 
@@ -51,7 +51,7 @@ namespace clove {
 
         open = true;
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Window created");
+        CLOVE_LOG(Clove, LogLevel::Trace, "Window created");
     }
 
     LinuxWindow::~LinuxWindow() {

--- a/clove/components/core/platform/source/Mac/MacWindow.mm
+++ b/clove/components/core/platform/source/Mac/MacWindow.mm
@@ -27,7 +27,7 @@ namespace clove{
         //Window specific init
         NSString *nameString = [NSString stringWithCString:descriptor.title.c_str() encoding:[NSString defaultCStringEncoding]];
         if(nameString == nullptr) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Critical, "nameString returned nullptr. Aborting");
+            CLOVE_LOG(Clove, LogLevel::Critical, "nameString returned nullptr. Aborting");
             abort();
         }
         

--- a/clove/components/core/platform/source/Mac/MacWindow.mm
+++ b/clove/components/core/platform/source/Mac/MacWindow.mm
@@ -2,6 +2,8 @@
 
 #include <Clove/Log/Log.hpp>
 
+CLOVE_DECLARE_LOG_CATEGORY(ClovePlatformMacOS)
+
 @implementation MacWindowProxy
 - (void)windowWillClose:(NSNotification *)notification {
     _cloveWindow->close();
@@ -17,6 +19,8 @@
 namespace clove{
     MacWindow::MacWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
+        CLOVE_LOG(ClovePlatformMacOS, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
+
         //Application specific init
         [NSApplication sharedApplication];
         [NSApp finishLaunching];
@@ -27,7 +31,7 @@ namespace clove{
         //Window specific init
         NSString *nameString = [NSString stringWithCString:descriptor.title.c_str() encoding:[NSString defaultCStringEncoding]];
         if(nameString == nullptr) {
-            CLOVE_LOG(Clove, LogLevel::Critical, "nameString returned nullptr. Aborting");
+            CLOVE_LOG(ClovePlatformMacOS, LogLevel::Critical, "nameString returned nullptr. Aborting");
             abort();
         }
         
@@ -49,6 +53,8 @@ namespace clove{
         windowProxy.cloveWindow = this;
         
         open = true;
+
+        CLOVE_LOG(ClovePlatformMacOS, LogLevel::Trace, "Window created");
     }
     
     MacWindow::~MacWindow() = default;

--- a/clove/components/core/platform/source/Windows/WindowsWindow.cpp
+++ b/clove/components/core/platform/source/Windows/WindowsWindow.cpp
@@ -8,7 +8,7 @@
 namespace clove {
     WindowsWindow::WindowsWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
+        CLOVE_LOG(Clove, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
 
         instance = GetModuleHandle(nullptr);
 
@@ -27,7 +27,7 @@ namespace clove {
         };
         RegisterClassEx(&windowClass);
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Windows class registered");
+        CLOVE_LOG(Clove, LogLevel::Trace, "Windows class registered");
 
         std::string const wideTitle(descriptor.title.begin(), descriptor.title.end());
 
@@ -56,7 +56,7 @@ namespace clove {
 
         open = true;
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Window created");
+        CLOVE_LOG(Clove, LogLevel::Trace, "Window created");
     }
 
     WindowsWindow::~WindowsWindow() {

--- a/clove/components/core/platform/source/Windows/WindowsWindow.cpp
+++ b/clove/components/core/platform/source/Windows/WindowsWindow.cpp
@@ -5,10 +5,12 @@
 
 #define CLV_WINDOWS_QUIT 25397841//Note: this number is completely random
 
+CLOVE_DECLARE_LOG_CATEGORY(ClovePlatformWindows)
+
 namespace clove {
     WindowsWindow::WindowsWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(Clove, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
+        CLOVE_LOG(ClovePlatformWindows, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
 
         instance = GetModuleHandle(nullptr);
 
@@ -27,7 +29,7 @@ namespace clove {
         };
         RegisterClassEx(&windowClass);
 
-        CLOVE_LOG(Clove, LogLevel::Trace, "Windows class registered");
+        CLOVE_LOG(ClovePlatformWindows, LogLevel::Trace, "Windows class registered");
 
         std::string const wideTitle(descriptor.title.begin(), descriptor.title.end());
 
@@ -56,7 +58,7 @@ namespace clove {
 
         open = true;
 
-        CLOVE_LOG(Clove, LogLevel::Trace, "Window created");
+        CLOVE_LOG(ClovePlatformWindows, LogLevel::Trace, "Window created");
     }
 
     WindowsWindow::~WindowsWindow() {

--- a/clove/components/systems/ai/include/Clove/AI/BlackBoard.inl
+++ b/clove/components/systems/ai/include/Clove/AI/BlackBoard.inl
@@ -7,7 +7,7 @@ namespace clove {
         if(dataMap.find(key) == dataMap.end()) {
             void *block = memoryBlock.alloc<DataType>();
             if(block == nullptr) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Could not allocate space for new item", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(Clove, LogLevel::Error, "{0}: Could not allocate space for new item", CLOVE_FUNCTION_NAME);
                 return;
             }
 

--- a/clove/components/systems/ai/include/Clove/AI/BlackBoard.inl
+++ b/clove/components/systems/ai/include/Clove/AI/BlackBoard.inl
@@ -1,13 +1,15 @@
 #include <Clove/Definitions.hpp>
 #include <Clove/Log/Log.hpp>
 
+CLOVE_DECLARE_LOG_CATEGORY(CloveAi)
+
 namespace clove {
     template<typename DataType>
     void BlackBoard::setValue(Key key, DataType value) {
         if(dataMap.find(key) == dataMap.end()) {
             void *block = memoryBlock.alloc<DataType>();
             if(block == nullptr) {
-                CLOVE_LOG(Clove, LogLevel::Error, "{0}: Could not allocate space for new item", CLOVE_FUNCTION_NAME);
+                CLOVE_LOG(CloveAi, LogLevel::Error, "{0}: Could not allocate space for new item", CLOVE_FUNCTION_NAME);
                 return;
             }
 

--- a/clove/components/systems/ecs/include/Clove/ECS/ComponentContainer.inl
+++ b/clove/components/systems/ecs/include/Clove/ECS/ComponentContainer.inl
@@ -5,6 +5,8 @@
 #include <Clove/Log/Log.hpp>
 #include <type_traits>
 
+CLOVE_DECLARE_LOG_CATEGORY(CloveEcs)
+
 namespace clove {
     bool ComponentContainerInterface::hasComponent(Entity entity) {
         return entity != NullEntity && entityToIndex.size() > entity && entityToIndex[entity] != nullIndex;
@@ -68,7 +70,7 @@ namespace clove {
         if constexpr(std::is_copy_constructible_v<ComponentType>) {
             addComponent(to, getComponent(from));
         } else {
-            CLOVE_LOG(Clove, LogLevel::Warning, "{0}: Component is not copy constructable. Entity {1} will be incomplete.", CLOVE_FUNCTION_NAME_PRETTY, to);
+            CLOVE_LOG(CloveEcs, LogLevel::Warning, "{0}: Component is not copy constructable. Entity {1} will be incomplete.", CLOVE_FUNCTION_NAME_PRETTY, to);
         }
     }
 

--- a/clove/components/systems/ecs/include/Clove/ECS/ComponentContainer.inl
+++ b/clove/components/systems/ecs/include/Clove/ECS/ComponentContainer.inl
@@ -61,7 +61,7 @@ namespace clove {
 
     template<typename ComponentType>
     ComponentType &ComponentContainer<ComponentType>::getComponent(Entity entity) {
-        CLOVE_ASSERT(hasComponent(entity), "{0}: Entity does not have component", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(hasComponent(entity), "{0}: Entity does not have component", CLOVE_FUNCTION_NAME_PRETTY);
         return components[entityToIndex[entity]];
     }
 

--- a/clove/components/systems/ecs/include/Clove/ECS/ComponentContainer.inl
+++ b/clove/components/systems/ecs/include/Clove/ECS/ComponentContainer.inl
@@ -68,7 +68,7 @@ namespace clove {
         if constexpr(std::is_copy_constructible_v<ComponentType>) {
             addComponent(to, getComponent(from));
         } else {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "{0}: Component is not copy constructable. Entity {1} will be incomplete.", CLOVE_FUNCTION_NAME_PRETTY, to);
+            CLOVE_LOG(Clove, LogLevel::Warning, "{0}: Component is not copy constructable. Entity {1} will be incomplete.", CLOVE_FUNCTION_NAME_PRETTY, to);
         }
     }
 

--- a/clove/components/systems/ecs/include/Clove/ECS/EntityManager.inl
+++ b/clove/components/systems/ecs/include/Clove/ECS/EntityManager.inl
@@ -7,13 +7,13 @@ namespace clove {
 
     template<typename ComponentType, typename... ConstructArgs>
     ComponentType &EntityManager::addComponent(Entity entity, ConstructArgs &&... args) {
-        CLOVE_ASSERT(isValid(entity), "{0}: Invalid entity provided", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(isValid(entity), "{0}: Invalid entity provided", CLOVE_FUNCTION_NAME_PRETTY);
         return componentManager.addComponent<ComponentType>(entity, std::forward<ConstructArgs>(args)...);
     }
 
     template<typename ComponentType>
     ComponentType &EntityManager::getComponent(Entity entity) {
-        CLOVE_ASSERT(isValid(entity), "{0}: Invalid entity provided", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(isValid(entity), "{0}: Invalid entity provided", CLOVE_FUNCTION_NAME_PRETTY);
         return componentManager.getComponent<ComponentType>(entity);
     }
 

--- a/clove/components/systems/serialisation/include/Clove/Serialisation/Node.hpp
+++ b/clove/components/systems/serialisation/include/Clove/Serialisation/Node.hpp
@@ -92,13 +92,13 @@ namespace clove::serialiser {
 namespace clove {
     template<typename UnkownType>
     serialiser::Node serialise(UnkownType const &object) {
-        CLOVE_ASSERT(false, "No template specialisation provided");
+        CLOVE_ASSERT_MSG(false, "No template specialisation provided");
         return {};
     }
 
     template<typename UnkownType>
     UnkownType deserialise(serialiser::Node const &node) {
-        CLOVE_ASSERT(false, "No template specialisation provided");
+        CLOVE_ASSERT_MSG(false, "No template specialisation provided");
         return {};
     }
 }

--- a/clove/components/utilities/cast/include/Clove/Cast.inl
+++ b/clove/components/utilities/cast/include/Clove/Cast.inl
@@ -5,7 +5,7 @@ namespace clove {
     DestType *polyCast(SourceType *source) {
 #if CLOVE_SAFE_CAST
         auto *result{ dynamic_cast<DestType *>(source) };
-        CLOVE_ASSERT(result != nullptr, "Cast failed");
+        CLOVE_ASSERT_MSG(result != nullptr, "Cast failed");
         return result;
 #else
         return static_cast<DestType *>(source);

--- a/clove/components/utilities/log/include/Clove/Log/Log.hpp
+++ b/clove/components/utilities/log/include/Clove/Log/Log.hpp
@@ -5,11 +5,6 @@
 #include <string>
 #include <string_view>
 
-#define CLOVE_DECLARE_LOG_CATEGORY(categoryName)                 \
-    struct LOG_CATEGORY_##categoryName {                         \
-        static std::string_view constexpr name{ #categoryName }; \
-    };
-
 namespace spdlog {
     class logger;
     namespace sinks {
@@ -51,20 +46,27 @@ namespace clove {
     };
 }
 
-#define CLOVE_LOG(category, level, ...) ::clove::Logger::get().log(category::name, level, __VA_ARGS__);
+#define CLOVE_EXPAND_CATEGORY(category) LOG_CATEGORY_##category
+
+#define CLOVE_DECLARE_LOG_CATEGORY(categoryName)                 \
+    struct CLOVE_EXPAND_CATEGORY(categoryName) {                 \
+        static std::string_view constexpr name{ #categoryName }; \
+    };
+
+#define CLOVE_LOG(category, level, ...) ::clove::Logger::get().log(CLOVE_EXPAND_CATEGORY(category)::name, level, __VA_ARGS__);
 
 #if CLOVE_ENABLE_ASSERTIONS
-    #define CLOVE_ASSERT(x, ...)                                                                                  \
-        {                                                                                                         \
-            if(!(x)) {                                                                                            \
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, ::clove::LogLevel::Critical, "Assertion Failed: {0}", __VA_ARGS__); \
-                CLOVE_DEBUG_BREAK;                                                                                \
-            }                                                                                                     \
+    #define CLOVE_ASSERT(x, ...)                                                                     \
+        {                                                                                            \
+            if(!(x)) {                                                                               \
+                CLOVE_LOG(Clove, ::clove::LogLevel::Critical, "Assertion Failed: {0}", __VA_ARGS__); \
+                CLOVE_DEBUG_BREAK;                                                                   \
+            }                                                                                        \
         }
 #else
-    #define CLOVE_ASSERT(x, ...) (x)
+    #define CLOVE_ASSERT(x, ...)
 #endif
 
 #include "Log.inl"
 
-CLOVE_DECLARE_LOG_CATEGORY(CLOVE)
+CLOVE_DECLARE_LOG_CATEGORY(Clove)

--- a/clove/components/utilities/log/include/Clove/Log/Log.hpp
+++ b/clove/components/utilities/log/include/Clove/Log/Log.hpp
@@ -56,10 +56,12 @@ namespace clove {
 #define CLOVE_LOG(category, level, ...) ::clove::Logger::get().log(CLOVE_EXPAND_CATEGORY(category)::name, level, __VA_ARGS__);
 
 #if CLOVE_ENABLE_ASSERTIONS
+    CLOVE_DECLARE_LOG_CATEGORY(CloveAssert)
+    
     #define CLOVE_ASSERT(x, ...)                                                                     \
         {                                                                                            \
             if(!(x)) {                                                                               \
-                CLOVE_LOG(Clove, ::clove::LogLevel::Critical, "Assertion Failed: {0}", __VA_ARGS__); \
+                CLOVE_LOG(CloveAssert, ::clove::LogLevel::Critical, "Assertion Failed: {0}", __VA_ARGS__); \
                 CLOVE_DEBUG_BREAK;                                                                   \
             }                                                                                        \
         }
@@ -68,5 +70,3 @@ namespace clove {
 #endif
 
 #include "Log.inl"
-
-CLOVE_DECLARE_LOG_CATEGORY(Clove)

--- a/clove/components/utilities/log/include/Clove/Log/Log.hpp
+++ b/clove/components/utilities/log/include/Clove/Log/Log.hpp
@@ -56,17 +56,28 @@ namespace clove {
 #define CLOVE_LOG(category, level, ...) ::clove::Logger::get().log(CLOVE_EXPAND_CATEGORY(category)::name, level, __VA_ARGS__);
 
 #if CLOVE_ENABLE_ASSERTIONS
-    CLOVE_DECLARE_LOG_CATEGORY(CloveAssert)
-    
-    #define CLOVE_ASSERT(x, ...)                                                                     \
-        {                                                                                            \
-            if(!(x)) {                                                                               \
-                CLOVE_LOG(CloveAssert, ::clove::LogLevel::Critical, "Assertion Failed: {0}", __VA_ARGS__); \
-                CLOVE_DEBUG_BREAK;                                                                   \
-            }                                                                                        \
+CLOVE_DECLARE_LOG_CATEGORY(CloveAssert)
+
+    #define CLOVE_ASSERT(x)                                                                                                  \
+        {                                                                                                                    \
+            if(!(x)) {                                                                                                       \
+                CLOVE_LOG(CloveAssert, ::clove::LogLevel::Critical, "Assertion failed: {0}", #x);                            \
+                CLOVE_LOG(CloveAssert, ::clove::LogLevel::Critical, "Assertion function:\n{0}", CLOVE_FUNCTION_NAME_PRETTY); \
+                CLOVE_DEBUG_BREAK;                                                                                           \
+            }                                                                                                                \
+        }
+
+    #define CLOVE_ASSERT_MSG(x, ...)                                                                    \
+        {                                                                                               \
+            if(!(x)) {                                                                                  \
+                CLOVE_LOG(CloveAssert, ::clove::LogLevel::Critical, "Assertion failed: {0}", #x);       \
+                CLOVE_LOG(CloveAssert, ::clove::LogLevel::Critical, "Assertion message: " __VA_ARGS__); \
+                CLOVE_DEBUG_BREAK;                                                                      \
+            }                                                                                           \
         }
 #else
-    #define CLOVE_ASSERT(x, ...)
+    #define CLOVE_ASSERT(x)
+    #define CLOVE_ASSERT_MSG(x, ...)
 #endif
 
 #include "Log.inl"

--- a/clove/components/utilities/memory/CMakeLists.txt
+++ b/clove/components/utilities/memory/CMakeLists.txt
@@ -5,8 +5,9 @@ set(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 add_library(
 	CloveMemory STATIC
 		${INCLUDE}/AllocatorStrategy.hpp
-        ${INCLUDE}/ListAllocator.hpp
-        ${INCLUDE}/ListAllocator.inl
+		${INCLUDE}/ListAllocator.hpp
+		${INCLUDE}/ListAllocator.inl
+		${INCLUDE}/MemoryLog.hpp
 		${SOURCE}/ListAllocator.cpp
 		${INCLUDE}/PoolAllocator.hpp
 		${INCLUDE}/PoolAllocator.inl

--- a/clove/components/utilities/memory/include/Clove/Memory/MemoryLog.hpp
+++ b/clove/components/utilities/memory/include/Clove/Memory/MemoryLog.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Clove/Log/Log.hpp>
+
+CLOVE_DECLARE_LOG_CATEGORY(CloveMemory)

--- a/clove/components/utilities/memory/include/Clove/Memory/PoolAllocator.inl
+++ b/clove/components/utilities/memory/include/Clove/Memory/PoolAllocator.inl
@@ -1,5 +1,6 @@
+#include "Clove/Memory/MemoryLog.hpp"
+
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 
 namespace clove {
     template<typename ItemType, AllocatorStrategy strategy>
@@ -37,7 +38,7 @@ namespace clove {
                 arena          = std::move(newArena);
                 nextFree       = &arena->storage[0];
             } else {
-                CLOVE_LOG(Clove, LogLevel::Error, "{0}: At the end of the free list. Cannot allocate new elements", CLOVE_FUNCTION_NAME_PRETTY);
+                CLOVE_LOG(CloveMemory, LogLevel::Error, "{0}: At the end of the free list. Cannot allocate new elements", CLOVE_FUNCTION_NAME_PRETTY);
                 return nullptr;
             }
         }

--- a/clove/components/utilities/memory/include/Clove/Memory/PoolAllocator.inl
+++ b/clove/components/utilities/memory/include/Clove/Memory/PoolAllocator.inl
@@ -37,7 +37,7 @@ namespace clove {
                 arena          = std::move(newArena);
                 nextFree       = &arena->storage[0];
             } else {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: At the end of the free list. Cannot allocate new elements", CLOVE_FUNCTION_NAME_PRETTY);
+                CLOVE_LOG(Clove, LogLevel::Error, "{0}: At the end of the free list. Cannot allocate new elements", CLOVE_FUNCTION_NAME_PRETTY);
                 return nullptr;
             }
         }

--- a/clove/components/utilities/memory/source/ListAllocator.cpp
+++ b/clove/components/utilities/memory/source/ListAllocator.cpp
@@ -67,7 +67,7 @@ namespace clove {
             }
         }
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
+        CLOVE_LOG(Clove, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
         return nullptr;
     }
 

--- a/clove/components/utilities/memory/source/ListAllocator.cpp
+++ b/clove/components/utilities/memory/source/ListAllocator.cpp
@@ -1,6 +1,7 @@
 #include "Clove/Memory/ListAllocator.hpp"
 
-#include <Clove/Log/Log.hpp>
+#include "Clove/Memory/MemoryLog.hpp"
+
 #include <cstdlib>
 
 namespace clove {
@@ -67,7 +68,7 @@ namespace clove {
             }
         }
 
-        CLOVE_LOG(Clove, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
+        CLOVE_LOG(CloveMemory, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
         return nullptr;
     }
 

--- a/clove/components/utilities/memory/source/StackAllocator.cpp
+++ b/clove/components/utilities/memory/source/StackAllocator.cpp
@@ -36,7 +36,7 @@ namespace clove {
         size_t const totalAllocationSize{ size + alignment };
 
         if((top - stack) + totalAllocationSize > stackSize) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
+            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
             return nullptr;
         }
 

--- a/clove/components/utilities/memory/source/StackAllocator.cpp
+++ b/clove/components/utilities/memory/source/StackAllocator.cpp
@@ -1,7 +1,8 @@
 #include "Clove/Memory/StackAllocator.hpp"
 
+#include "Clove/Memory/MemoryLog.hpp"
+
 #include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
 #include <cstdlib>
 
 namespace clove {
@@ -36,7 +37,7 @@ namespace clove {
         size_t const totalAllocationSize{ size + alignment };
 
         if((top - stack) + totalAllocationSize > stackSize) {
-            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
+            CLOVE_LOG(CloveMemory, LogLevel::Error, "{0}: Not enough space left to allocate {1} bytes.", CLOVE_FUNCTION_NAME_PRETTY, totalAllocationSize);
             return nullptr;
         }
 

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -15,7 +15,7 @@ namespace clove {
 
         auto subSystem{ std::make_unique<SubSystemType>(std::forward<Args>(args)...) };
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
+        CLOVE_LOG(Clove, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
 
         subSystem->onAttach();
         subSystems[group].push_back(std::move(subSystem));
@@ -38,7 +38,7 @@ namespace clove {
         std::type_index const subSystemIndex{ typeid(SubSystemType) };
 
         if(subSystemToIndex.find(subSystemIndex) == subSystemToIndex.end()) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
+            CLOVE_LOG(Clove, LogLevel::Warning, "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
             return;
         }
 

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -13,7 +13,7 @@ namespace clove {
         static_assert(std::is_base_of_v<SubSystem, SubSystemType>, "SubSystem provided is not derived from SubSystem.");
 
         std::type_index const subSystemIndex{ typeid(SubSystemType) };
-        CLOVE_ASSERT(subSystemToIndex.find(subSystemIndex) == subSystemToIndex.end(), "Only one subsystem can be active at a time.");
+        CLOVE_ASSERT_MSG(subSystemToIndex.find(subSystemIndex) == subSystemToIndex.end(), "Only one subsystem can be active at a time.");
 
         auto subSystem{ std::make_unique<SubSystemType>(std::forward<Args>(args)...) };
 
@@ -29,7 +29,7 @@ namespace clove {
     SubSystemType &Application::getSubSystem() {
         std::type_index const subSystemIndex{ typeid(SubSystemType) };
 
-        CLOVE_ASSERT(subSystemToIndex.find(subSystemIndex) != subSystemToIndex.end(), "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(subSystemToIndex.find(subSystemIndex) != subSystemToIndex.end(), "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
 
         auto &&[group, index] = subSystemToIndex.at(subSystemIndex);
         return *static_cast<SubSystemType *>(subSystems[group][index].get());

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -1,5 +1,7 @@
 #include <Clove/Log/Log.hpp>
 
+CLOVE_DECLARE_LOG_CATEGORY(CloveApp)
+
 namespace clove {
     template<typename SubSystemType, typename... Args>
     void Application::pushSubSystem(Args &&...args) {
@@ -15,7 +17,7 @@ namespace clove {
 
         auto subSystem{ std::make_unique<SubSystemType>(std::forward<Args>(args)...) };
 
-        CLOVE_LOG(Clove, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
+        CLOVE_LOG(CloveApp, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
 
         subSystem->onAttach();
         subSystems[group].push_back(std::move(subSystem));
@@ -38,7 +40,7 @@ namespace clove {
         std::type_index const subSystemIndex{ typeid(SubSystemType) };
 
         if(subSystemToIndex.find(subSystemIndex) == subSystemToIndex.end()) {
-            CLOVE_LOG(Clove, LogLevel::Warning, "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
+            CLOVE_LOG(CloveApp, LogLevel::Warning, "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
             return;
         }
 

--- a/clove/include/Clove/FileSystem/AssetPtr.inl
+++ b/clove/include/Clove/FileSystem/AssetPtr.inl
@@ -41,7 +41,7 @@ namespace clove {
 
     template<typename AssetType>
     AssetType &AssetPtr<AssetType>::get() {
-        CLOVE_ASSERT(isValid(), "{0}: AssetPtr requires a valid path before it can load");
+        CLOVE_ASSERT_MSG(isValid(), "{0}: AssetPtr requires a valid path before it can load");
 
         if(!isLoaded()) {
             *asset = loadFunction();
@@ -52,7 +52,7 @@ namespace clove {
 
     template<typename AssetType>
     AssetType const &AssetPtr<AssetType>::get() const {
-        CLOVE_ASSERT(isValid(), "{0}: AssetPtr requires a valid path before it can load");
+        CLOVE_ASSERT_MSG(isValid(), "{0}: AssetPtr requires a valid path before it can load");
 
         if(!isLoaded()) {
             *asset = loadFunction();

--- a/clove/include/Clove/FileSystem/AssetPtr.inl
+++ b/clove/include/Clove/FileSystem/AssetPtr.inl
@@ -41,7 +41,7 @@ namespace clove {
 
     template<typename AssetType>
     AssetType &AssetPtr<AssetType>::get() {
-        CLOVE_ASSERT_MSG(isValid(), "{0}: AssetPtr requires a valid path before it can load");
+        CLOVE_ASSERT_MSG(isValid(), "{0}: AssetPtr requires a valid path before it can load", CLOVE_FUNCTION_NAME_PRETTY);
 
         if(!isLoaded()) {
             *asset = loadFunction();
@@ -52,7 +52,7 @@ namespace clove {
 
     template<typename AssetType>
     AssetType const &AssetPtr<AssetType>::get() const {
-        CLOVE_ASSERT_MSG(isValid(), "{0}: AssetPtr requires a valid path before it can load");
+        CLOVE_ASSERT_MSG(isValid(), "{0}: AssetPtr requires a valid path before it can load", CLOVE_FUNCTION_NAME_PRETTY);
 
         if(!isLoaded()) {
             *asset = loadFunction();

--- a/clove/include/Clove/Rendering/RenderingLog.hpp
+++ b/clove/include/Clove/Rendering/RenderingLog.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Clove/Log/Log.hpp>
+
+CLOVE_DECLARE_LOG_CATEGORY(CloveRendering)

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -113,7 +113,7 @@ namespace clove {
         , audioDevice{ std::move(audioDevice) }
         , surface{ std::move(surface) }
         , assetManager{ &fileSystem } {
-        CLOVE_ASSERT(instance == nullptr, "Only one Application can be active");
+        CLOVE_ASSERT_MSG(instance == nullptr, "Only one Application can be active");
         instance = this;
 
         prevFrameTime = std::chrono::system_clock::now();

--- a/clove/source/FileSystem/VirtualFileSystem.cpp
+++ b/clove/source/FileSystem/VirtualFileSystem.cpp
@@ -2,6 +2,8 @@
 
 #include <Clove/Log/Log.hpp>
 
+CLOVE_DECLARE_LOG_CATEGORY(CloveFileSystem)
+
 namespace clove {
     VirtualFileSystem::VirtualFileSystem() = default;
 
@@ -26,7 +28,7 @@ namespace clove {
                 fullPath /= relPath;
             }
         } else {
-            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Unknown VFS root: \"{1}\". Returning empty path", CLOVE_FUNCTION_NAME, vfsRoot);
+            CLOVE_LOG(CloveFileSystem, LogLevel::Error, "{0}: Unknown VFS root: \"{1}\". Returning empty path", CLOVE_FUNCTION_NAME, vfsRoot);
         }
 
         return fullPath.make_preferred();

--- a/clove/source/FileSystem/VirtualFileSystem.cpp
+++ b/clove/source/FileSystem/VirtualFileSystem.cpp
@@ -26,7 +26,7 @@ namespace clove {
                 fullPath /= relPath;
             }
         } else {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0}: Unknown VFS root: \"{1}\". Returning empty path", CLOVE_FUNCTION_NAME, vfsRoot);
+            CLOVE_LOG(Clove, LogLevel::Error, "{0}: Unknown VFS root: \"{1}\". Returning empty path", CLOVE_FUNCTION_NAME, vfsRoot);
         }
 
         return fullPath.make_preferred();

--- a/clove/source/ModelLoader.cpp
+++ b/clove/source/ModelLoader.cpp
@@ -347,14 +347,14 @@ namespace clove::ModelLoader {
     StaticModel loadStaticModel(std::filesystem::path const &modelFilePath) {
         CLOVE_PROFILE_FUNCTION();
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Loading static model: {0}", modelFilePath.string());
+        CLOVE_LOG(Clove, LogLevel::Trace, "Loading static model: {0}", modelFilePath.string());
 
         std::vector<std::shared_ptr<Mesh>> meshes;
 
         Assimp::Importer importer;
         const aiScene *scene{ openFile(modelFilePath, importer) };
         if(scene == nullptr || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0u) || scene->mRootNode == nullptr) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
+            CLOVE_LOG(Clove, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
             return { meshes };
         }
 
@@ -363,7 +363,7 @@ namespace clove::ModelLoader {
             meshes.emplace_back(processMesh(mesh, scene, MeshType::Default));
         }
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Debug, "Finished loading static model: {0}", modelFilePath.string());
+        CLOVE_LOG(Clove, LogLevel::Debug, "Finished loading static model: {0}", modelFilePath.string());
         //TEMP: Storing the path of the model for serialisation purposes
         StaticModel model{ meshes };
         return model;
@@ -372,7 +372,7 @@ namespace clove::ModelLoader {
     AnimatedModel loadAnimatedModel(std::filesystem::path const &modelFilePath) {
         CLOVE_PROFILE_FUNCTION();
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Loading animated model: {0}", modelFilePath.string());
+        CLOVE_LOG(Clove, LogLevel::Trace, "Loading animated model: {0}", modelFilePath.string());
 
         std::vector<std::shared_ptr<Mesh>> meshes;
         std::unique_ptr<Skeleton> skeleton{ std::make_unique<Skeleton>() };//TODO: Support multiple skeletons?
@@ -380,7 +380,7 @@ namespace clove::ModelLoader {
         Assimp::Importer importer;
         const aiScene *scene{ openFile(modelFilePath, importer) };
         if(scene == nullptr || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0u) || scene->mRootNode == nullptr) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
+            CLOVE_LOG(Clove, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
             return { meshes, nullptr, {} };
         }
 
@@ -397,7 +397,7 @@ namespace clove::ModelLoader {
             if(mesh->mNumBones <= 0) {
                 continue;
             } else if(skeletonSet) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "Multiple skeletons detected in {0}. Currently Clove only support one skeleton per model. Animations may be innacrate.", modelFilePath.string());
+                CLOVE_LOG(Clove, LogLevel::Warning, "Multiple skeletons detected in {0}. Currently Clove only support one skeleton per model. Animations may be innacrate.", modelFilePath.string());
                 continue;
             }
 
@@ -423,7 +423,7 @@ namespace clove::ModelLoader {
         }
 
         if(skeleton->joints.size() > MAX_JOINTS) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Error, "{0} has too many joints (Max supported {1}, current amount {2}). Could not import animations", modelFilePath.string(), MAX_JOINTS, skeleton->joints.size());
+            CLOVE_LOG(Clove, LogLevel::Error, "{0} has too many joints (Max supported {1}, current amount {2}). Could not import animations", modelFilePath.string(), MAX_JOINTS, skeleton->joints.size());
             return { meshes, nullptr, {} };
         }
 
@@ -478,7 +478,7 @@ namespace clove::ModelLoader {
             }
         }
 
-        CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Debug, "Finished loading animated model: {0}", modelFilePath.string());
+        CLOVE_LOG(Clove, LogLevel::Debug, "Finished loading animated model: {0}", modelFilePath.string());
         return { meshes, std::move(skeleton), std::move(animationClips) };
     }
 }

--- a/clove/source/ModelLoader.cpp
+++ b/clove/source/ModelLoader.cpp
@@ -17,6 +17,8 @@
 #include <map>
 #include <set>
 
+CLOVE_DECLARE_LOG_CATEGORY(CloveModelLoader)
+
 namespace clove::ModelLoader {
     namespace {
         mat4f convert(aiMatrix4x4 const &aiMat) {
@@ -347,14 +349,14 @@ namespace clove::ModelLoader {
     StaticModel loadStaticModel(std::filesystem::path const &modelFilePath) {
         CLOVE_PROFILE_FUNCTION();
 
-        CLOVE_LOG(Clove, LogLevel::Trace, "Loading static model: {0}", modelFilePath.string());
+        CLOVE_LOG(CloveModelLoader, LogLevel::Trace, "Loading static model: {0}", modelFilePath.string());
 
         std::vector<std::shared_ptr<Mesh>> meshes;
 
         Assimp::Importer importer;
         const aiScene *scene{ openFile(modelFilePath, importer) };
         if(scene == nullptr || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0u) || scene->mRootNode == nullptr) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
+            CLOVE_LOG(CloveModelLoader, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
             return { meshes };
         }
 
@@ -363,7 +365,7 @@ namespace clove::ModelLoader {
             meshes.emplace_back(processMesh(mesh, scene, MeshType::Default));
         }
 
-        CLOVE_LOG(Clove, LogLevel::Debug, "Finished loading static model: {0}", modelFilePath.string());
+        CLOVE_LOG(CloveModelLoader, LogLevel::Debug, "Finished loading static model: {0}", modelFilePath.string());
         //TEMP: Storing the path of the model for serialisation purposes
         StaticModel model{ meshes };
         return model;
@@ -372,7 +374,7 @@ namespace clove::ModelLoader {
     AnimatedModel loadAnimatedModel(std::filesystem::path const &modelFilePath) {
         CLOVE_PROFILE_FUNCTION();
 
-        CLOVE_LOG(Clove, LogLevel::Trace, "Loading animated model: {0}", modelFilePath.string());
+        CLOVE_LOG(CloveModelLoader, LogLevel::Trace, "Loading animated model: {0}", modelFilePath.string());
 
         std::vector<std::shared_ptr<Mesh>> meshes;
         std::unique_ptr<Skeleton> skeleton{ std::make_unique<Skeleton>() };//TODO: Support multiple skeletons?
@@ -380,7 +382,7 @@ namespace clove::ModelLoader {
         Assimp::Importer importer;
         const aiScene *scene{ openFile(modelFilePath, importer) };
         if(scene == nullptr || ((scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) != 0u) || scene->mRootNode == nullptr) {
-            CLOVE_LOG(Clove, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
+            CLOVE_LOG(CloveModelLoader, LogLevel::Error, "Assimp Error: {0}", importer.GetErrorString());
             return { meshes, nullptr, {} };
         }
 
@@ -397,7 +399,7 @@ namespace clove::ModelLoader {
             if(mesh->mNumBones <= 0) {
                 continue;
             } else if(skeletonSet) {
-                CLOVE_LOG(Clove, LogLevel::Warning, "Multiple skeletons detected in {0}. Currently Clove only support one skeleton per model. Animations may be innacrate.", modelFilePath.string());
+                CLOVE_LOG(CloveModelLoader, LogLevel::Warning, "Multiple skeletons detected in {0}. Currently Clove only support one skeleton per model. Animations may be innacrate.", modelFilePath.string());
                 continue;
             }
 
@@ -423,7 +425,7 @@ namespace clove::ModelLoader {
         }
 
         if(skeleton->joints.size() > MAX_JOINTS) {
-            CLOVE_LOG(Clove, LogLevel::Error, "{0} has too many joints (Max supported {1}, current amount {2}). Could not import animations", modelFilePath.string(), MAX_JOINTS, skeleton->joints.size());
+            CLOVE_LOG(CloveModelLoader, LogLevel::Error, "{0} has too many joints (Max supported {1}, current amount {2}). Could not import animations", modelFilePath.string(), MAX_JOINTS, skeleton->joints.size());
             return { meshes, nullptr, {} };
         }
 
@@ -478,7 +480,7 @@ namespace clove::ModelLoader {
             }
         }
 
-        CLOVE_LOG(Clove, LogLevel::Debug, "Finished loading animated model: {0}", modelFilePath.string());
+        CLOVE_LOG(CloveModelLoader, LogLevel::Debug, "Finished loading animated model: {0}", modelFilePath.string());
         return { meshes, std::move(skeleton), std::move(animationClips) };
     }
 }

--- a/clove/source/Rendering/ForwardRenderer3D.cpp
+++ b/clove/source/Rendering/ForwardRenderer3D.cpp
@@ -196,7 +196,7 @@ namespace clove {
         //Aquire the next available image from the render target
         Expected<uint32_t, std::string> const result{ renderTarget->aquireNextImage(currentFrame) };
         if(!result.hasValue()) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Debug, result.getError());
+            CLOVE_LOG(Clove, LogLevel::Debug, result.getError());
             return;
         }
 

--- a/clove/source/Rendering/ForwardRenderer3D.cpp
+++ b/clove/source/Rendering/ForwardRenderer3D.cpp
@@ -10,12 +10,12 @@
 #include "Clove/Rendering/RenderTarget.hpp"
 #include "Clove/Rendering/Renderables/Mesh.hpp"
 #include "Clove/Rendering/RenderingHelpers.hpp"
+#include "Clove/Rendering/RenderingLog.hpp"
 #include "Clove/Rendering/Vertex.hpp"
 
 #include <Clove/Graphics/GhaDescriptorSet.hpp>
 #include <Clove/Graphics/GhaImageView.hpp>
 #include <Clove/Graphics/Graphics.hpp>
-#include <Clove/Log/Log.hpp>
 #include <Clove/Platform/Window.hpp>
 
 extern "C" const char constants[];
@@ -93,9 +93,9 @@ namespace clove {
         createRenderTargetResources();
 
         //Create semaphores for frame synchronisation
-		for(auto &skinningFinishedSemaphore : skinningFinishedSemaphores) {
-			skinningFinishedSemaphore = *ghaFactory->createSemaphore();
-		}
+        for(auto &skinningFinishedSemaphore : skinningFinishedSemaphores) {
+            skinningFinishedSemaphore = *ghaFactory->createSemaphore();
+        }
 
         std::vector<Vertex> const uiVertices{
             Vertex{
@@ -196,7 +196,7 @@ namespace clove {
         //Aquire the next available image from the render target
         Expected<uint32_t, std::string> const result{ renderTarget->aquireNextImage(currentFrame) };
         if(!result.hasValue()) {
-            CLOVE_LOG(Clove, LogLevel::Debug, result.getError());
+            CLOVE_LOG(CloveRendering, LogLevel::Debug, result.getError());
             return;
         }
 
@@ -616,7 +616,7 @@ namespace clove {
             imageData.lightingDescriptorSet->map(*imageData.frameDataBuffer, offsetof(FrameData::BufferData, directionalShadowTransforms), sizeof(currentFrameData.bufferData.directionalShadowTransforms), DescriptorType::UniformBuffer, 2);
             imageData.lightingDescriptorSet->map(*imageData.shadowMapViews, GhaImage::Layout::ShaderReadOnlyOptimal, 3);
             imageData.lightingDescriptorSet->map(*imageData.cubeShadowMapViews, GhaImage::Layout::ShaderReadOnlyOptimal, 4);
-            imageData.lightingDescriptorSet->map(*shadowSampler, 5); //NOLINT
+            imageData.lightingDescriptorSet->map(*shadowSampler, 5);//NOLINT
         }
     }
 

--- a/clove/source/Rendering/GraphicsImageRenderTarget.cpp
+++ b/clove/source/Rendering/GraphicsImageRenderTarget.cpp
@@ -75,7 +75,7 @@ namespace clove {
     }
 
     GhaBuffer *GraphicsImageRenderTarget::getNextReadyBuffer() {
-        CLOVE_ASSERT(!requiresResize, "Cannot get next ready buffer while a resize is pending");
+        CLOVE_ASSERT_MSG(!requiresResize, "Cannot get next ready buffer while a resize is pending");
 
         //Stall until we are ready to return the image.
         frameInFlight->wait();

--- a/clove/source/Rendering/Renderables/AnimatedModel.cpp
+++ b/clove/source/Rendering/Renderables/AnimatedModel.cpp
@@ -1,6 +1,7 @@
 #include "Clove/Rendering/Renderables/AnimatedModel.hpp"
 
 #include "Clove/Rendering/Techniques/ForwardLightingTechnique.hpp"
+#include "Clove/Rendering/RenderingLog.hpp"
 
 #include <Clove/Log/Log.hpp>
 
@@ -9,8 +10,8 @@ namespace clove {
         : StaticModel{ std::move(meshes), { createSkinnedForwardLightingTechnique() } }
         , skeleton{ std::move(skeleton) }
         , animClips{ std::move(animClips) } {
-        if(std::size(this->animClips) == 0) {
-            CLOVE_LOG(Clove, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
+        if(this->animClips.size() == 0) {
+            CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&this->animClips[0]);
         }
@@ -24,8 +25,8 @@ namespace clove {
             clip.skeleton = skeleton.get();
         }
 
-        if(std::size(animClips) == 0) {
-            CLOVE_LOG(Clove, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
+        if(this->animClips.size() == 0) {
+            CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&animClips[0]);
         }
@@ -48,7 +49,7 @@ namespace clove {
         }
 
         if(std::size(animClips) == 0) {
-            CLOVE_LOG(Clove, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
+            CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&animClips[0]);
         }

--- a/clove/source/Rendering/Renderables/AnimatedModel.cpp
+++ b/clove/source/Rendering/Renderables/AnimatedModel.cpp
@@ -10,7 +10,7 @@ namespace clove {
         : StaticModel{ std::move(meshes), { createSkinnedForwardLightingTechnique() } }
         , skeleton{ std::move(skeleton) }
         , animClips{ std::move(animClips) } {
-        if(this->animClips.size() == 0) {
+        if(this->animClips.empty()) {
             CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&this->animClips[0]);
@@ -25,7 +25,7 @@ namespace clove {
             clip.skeleton = skeleton.get();
         }
 
-        if(this->animClips.size() == 0) {
+        if(this->animClips.empty()) {
             CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&animClips[0]);

--- a/clove/source/Rendering/Renderables/AnimatedModel.cpp
+++ b/clove/source/Rendering/Renderables/AnimatedModel.cpp
@@ -10,7 +10,7 @@ namespace clove {
         , skeleton{ std::move(skeleton) }
         , animClips{ std::move(animClips) } {
         if(std::size(this->animClips) == 0) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
+            CLOVE_LOG(Clove, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&this->animClips[0]);
         }
@@ -25,7 +25,7 @@ namespace clove {
         }
 
         if(std::size(animClips) == 0) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
+            CLOVE_LOG(Clove, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&animClips[0]);
         }
@@ -48,7 +48,7 @@ namespace clove {
         }
 
         if(std::size(animClips) == 0) {
-            CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
+            CLOVE_LOG(Clove, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
         } else {
             animator.setCurrentClip(&animClips[0]);
         }

--- a/clove/source/Rendering/Renderables/Font.cpp
+++ b/clove/source/Rendering/Renderables/Font.cpp
@@ -24,7 +24,7 @@ namespace clove {
 
         Font::FacePtr copyFace(FT_Face face) {
             if(FT_Reference_Face(face) != FT_Err_Ok) {
-                CLOVE_ASSERT(false, "Could not reference face");
+                CLOVE_ASSERT_MSG(false, "Could not reference face");
             }
             return makeUniqueFace(face);
         }
@@ -38,7 +38,7 @@ namespace clove {
         if(ftLib.use_count() == 0) {
             FT_Library library{ nullptr };
             if(FT_Init_FreeType(&library) != FT_Err_Ok) {
-                CLOVE_ASSERT(false, "Could not load freetype");
+                CLOVE_ASSERT_MSG(false, "Could not load freetype");
             } else {
                 CLOVE_LOG(FreeType, LogLevel::Trace, "Constructed FreeType library");
             }
@@ -134,7 +134,7 @@ namespace clove {
     Font::FacePtr Font::createFace(std::string const &filePath) {
         FT_Face face{ nullptr };
         if(FT_New_Face(ftLibReference.get(), filePath.c_str(), 0, &face) != FT_Err_Ok) {
-            CLOVE_ASSERT(false, "Could not load font");
+            CLOVE_ASSERT_MSG(false, "Could not load font");
         }
 
         return makeUniqueFace(face);
@@ -143,7 +143,7 @@ namespace clove {
     Font::FacePtr Font::createFace(std::span<std::byte const> bytes) {
         FT_Face face{ nullptr };
         if(FT_New_Memory_Face(ftLibReference.get(), reinterpret_cast<unsigned char const *>(bytes.data()), static_cast<FT_Long>(bytes.size_bytes()), 0, &face) != FT_Err_Ok) {
-            CLOVE_ASSERT(false, "Could not load font");
+            CLOVE_ASSERT_MSG(false, "Could not load font");
         }
 
         return makeUniqueFace(face);

--- a/clove/source/Rendering/Renderables/Font.cpp
+++ b/clove/source/Rendering/Renderables/Font.cpp
@@ -14,18 +14,22 @@
 extern "C" const unsigned char roboto_black[];
 extern "C" const size_t roboto_blackLength;
 
+CLOVE_DECLARE_LOG_CATEGORY(FreeType)
+
 namespace clove {
-    static Font::FacePtr makeUniqueFace(FT_Face face) {
-        return Font::FacePtr(face, [](FT_Face face) { FT_Done_Face(face); });
-    }
-
-    static Font::FacePtr copyFace(FT_Face face) {
-        if(FT_Reference_Face(face) != FT_Err_Ok) {
-            CLOVE_ASSERT(false, "Could not reference face");
+    namespace {
+        Font::FacePtr makeUniqueFace(FT_Face face) {
+            return Font::FacePtr(face, [](FT_Face face) { FT_Done_Face(face); });
         }
-        return makeUniqueFace(face);
-    }
 
+        Font::FacePtr copyFace(FT_Face face) {
+            if(FT_Reference_Face(face) != FT_Err_Ok) {
+                CLOVE_ASSERT(false, "Could not reference face");
+            }
+            return makeUniqueFace(face);
+        }
+    }
+    
     Font::FTLibWeakPtr Font::ftLib = {};
 
     Font::Font()
@@ -36,11 +40,11 @@ namespace clove {
             if(FT_Init_FreeType(&library) != FT_Err_Ok) {
                 CLOVE_ASSERT(false, "Could not load freetype");
             } else {
-                CLOVE_LOG(Clove, LogLevel::Trace, "Constructed FreeType library");
+                CLOVE_LOG(FreeType, LogLevel::Trace, "Constructed FreeType library");
             }
 
             auto const libraryDeleter = [](FT_Library lib) {
-                CLOVE_LOG(Clove, LogLevel::Trace, "FreeType library has been deleted");
+                CLOVE_LOG(FreeType, LogLevel::Trace, "FreeType library has been deleted");
                 FT_Done_FreeType(lib);
             };
             ftLibReference = FTLibSharedPtr(library, libraryDeleter);

--- a/clove/source/Rendering/Renderables/Font.cpp
+++ b/clove/source/Rendering/Renderables/Font.cpp
@@ -36,11 +36,11 @@ namespace clove {
             if(FT_Init_FreeType(&library) != FT_Err_Ok) {
                 CLOVE_ASSERT(false, "Could not load freetype");
             } else {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "Constructed FreeType library");
+                CLOVE_LOG(Clove, LogLevel::Trace, "Constructed FreeType library");
             }
 
             auto const libraryDeleter = [](FT_Library lib) {
-                CLOVE_LOG(LOG_CATEGORY_CLOVE, LogLevel::Trace, "FreeType library has been deleted");
+                CLOVE_LOG(Clove, LogLevel::Trace, "FreeType library has been deleted");
                 FT_Done_FreeType(lib);
             };
             ftLibReference = FTLibSharedPtr(library, libraryDeleter);

--- a/clove/source/SoundFile.cpp
+++ b/clove/source/SoundFile.cpp
@@ -19,7 +19,7 @@ namespace clove {
                 case SoundFile::SeekPosition::End:
                     return SEEK_END;
                 default:
-                    CLOVE_ASSERT(false, "{0}: Default statement hit", CLOVE_FUNCTION_NAME);
+                    CLOVE_ASSERT_MSG(false, "{0}: Default statement hit", CLOVE_FUNCTION_NAME);
                     return 0;
             }
         }
@@ -76,7 +76,7 @@ namespace clove {
             return Format::S32;
         }
 
-        CLOVE_ASSERT(false, "{0}, Unknown file format", CLOVE_FUNCTION_NAME_PRETTY);
+        CLOVE_ASSERT_MSG(false, "{0}, Unknown file format", CLOVE_FUNCTION_NAME_PRETTY);
         return Format::Unknown;
     }
 


### PR DESCRIPTION
## Summary
General refactors to the logging system to make using categories easier. Also added a new assertion macro specifically for asserting with a message

Closes #272 

## Changes
- Changed how log categories are declared. No longer requiring the user to write the generated part of the category type.
- Removed the default global 'Clove' log category. 
- Added a `CLOVE_ASSERT_MSG` macro to allow for properly formatted assertions with custom messages.