### PR TITLE
Add device information to the GhaDevice API

### DIFF
--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <string>
+#include <optional>
 
 namespace clove {
     class GhaFactory;
@@ -26,8 +27,8 @@ namespace clove {
         struct Info {
             std::string ApiName{};
             std::string deviceName{};
-            Version driverVersion{};
-            Version ApiVersion{};
+            std::optional<Version> driverVersion{}; /**< Not provided by some APIs. */
+            std::optional<Version> ApiVersion{};    /**< Not provided by some APIs. */
         };
 
         /**

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDevice.hpp
@@ -1,9 +1,16 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 namespace clove {
     class GhaFactory;
+
+    struct Version{
+        uint32_t major{ 0 };
+        uint32_t minor{ 0 };
+        uint32_t patch{ 0 };
+    };
 }
 
 namespace clove {
@@ -13,6 +20,16 @@ namespace clove {
     class GhaDevice {
         //TYPES
     public:
+        /**
+         * @brief Contains info about the device itself that the GHA is using.
+         */
+        struct Info {
+            std::string ApiName{};
+            std::string deviceName{};
+            Version driverVersion{};
+            Version ApiVersion{};
+        };
+
         /**
          * @brief Contains information about the limits of the device used by the GHA.
          */
@@ -36,6 +53,7 @@ namespace clove {
          */
         virtual void waitForIdleDevice() = 0;
 
+        virtual Info getInfo() const     = 0;
         virtual Limits getLimits() const = 0;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDevice.hpp
@@ -37,6 +37,7 @@ namespace clove {
 
 		void waitForIdleDevice() override;
 
+        Info getInfo() const override;
 		Limits getLimits() const override;
 	};
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDevice.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDevice.hpp
@@ -44,6 +44,7 @@ namespace clove {
 
         void waitForIdleDevice() override;
 
+        Info getInfo() const override;
         Limits getLimits() const override;
     };
 }

--- a/clove/components/core/graphics/source/Graphics.cpp
+++ b/clove/components/core/graphics/source/Graphics.cpp
@@ -48,9 +48,13 @@ namespace clove {
             GhaDevice::Info const info{ device->getInfo() };
 
             CLOVE_LOG(CloveGha, LogLevel::Trace, "GHA device created with a {0} backend.", info.ApiName);
-            CLOVE_LOG(CloveGha, LogLevel::Trace, "\tAPI:\t{0}.{1}.{2}", info.ApiVersion.major, info.ApiVersion.minor, info.ApiVersion.patch);
+            if(info.ApiVersion.has_value()) {
+                CLOVE_LOG(CloveGha, LogLevel::Trace, "\tAPI:\t{0}.{1}.{2}", info.ApiVersion->major, info.ApiVersion->minor, info.ApiVersion->patch);
+            }
             CLOVE_LOG(CloveGha, LogLevel::Trace, "\tDevice:\t{0}", info.deviceName);
-            CLOVE_LOG(CloveGha, LogLevel::Trace, "\tDriver:\t{0}.{1}.{2}", info.driverVersion.major, info.driverVersion.minor, info.driverVersion.patch);
+            if(info.driverVersion.has_value()) {
+                CLOVE_LOG(CloveGha, LogLevel::Trace, "\tDriver:\t{0}.{1}.{2}", info.driverVersion->major, info.driverVersion->minor, info.driverVersion->patch);
+            }
         } else {
             CLOVE_LOG(CloveGha, LogLevel::Error, "GHA Device creation failed.");
         }

--- a/clove/components/core/graphics/source/Metal/MetalDevice.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDevice.mm
@@ -45,6 +45,13 @@ namespace clove {
         //No op
     }
     
+    GhaDevice::Info MetalDevice::getInfo() const {
+        return Info {
+            .ApiName = "Metal",
+            .deviceName = [wrapper->device.name UTF8String],
+        };
+    }
+    
     GhaDevice::Limits MetalDevice::getLimits() const {
         size_t constexpr metalMinUboOffsetAlignment{ 16 };//Hard coding as a minimum of 16 as metal does not provide this data.
         

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -23,6 +23,7 @@
 #include <Clove/Definitions.hpp>
 #include <set>
 #include <unordered_set>
+#include <sstream>
 
 CLOVE_DECLARE_LOG_CATEGORY(Vulkan)
 
@@ -441,6 +442,26 @@ namespace clove {
                     break;
             }
         }
+    }
+
+    GhaDevice::Info VulkanDevice::getInfo() const {
+        VkPhysicalDeviceProperties devicePoperties;
+        vkGetPhysicalDeviceProperties(devicePtr.getPhysical(), &devicePoperties);
+
+        return Info{
+            .ApiName       = "Vulkan",
+            .deviceName    = devicePoperties.deviceName,
+            .driverVersion = {
+                .major = VK_VERSION_MAJOR(devicePoperties.driverVersion),
+                .minor = VK_VERSION_MINOR(devicePoperties.driverVersion),
+                .patch = VK_VERSION_PATCH(devicePoperties.driverVersion),
+            },
+            .ApiVersion = {
+                .major = VK_VERSION_MAJOR(devicePoperties.apiVersion),
+                .minor = VK_VERSION_MINOR(devicePoperties.apiVersion),
+                .patch = VK_VERSION_PATCH(devicePoperties.apiVersion),
+            },
+        };
     }
 
     GhaDevice::Limits VulkanDevice::getLimits() const {

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -352,14 +352,6 @@ namespace clove {
             if(physicalDevice == VK_NULL_HANDLE) {
                 CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Failed to find a suitable GPU!");
                 return;
-            } else {
-                VkPhysicalDeviceProperties devicePoperties;
-                vkGetPhysicalDeviceProperties(physicalDevice, &devicePoperties);
-
-                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "Vulkan capable physical device found");
-                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "\tDevice:\t{0}", devicePoperties.deviceName);
-                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "\tDriver:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.driverVersion), VK_VERSION_MINOR(devicePoperties.driverVersion), VK_VERSION_PATCH(devicePoperties.driverVersion));
-                CLOVE_LOG(CloveGhaVulkan, LogLevel::Info, "\tAPI:\t{0}.{1}.{2}", VK_VERSION_MAJOR(devicePoperties.apiVersion), VK_VERSION_MINOR(devicePoperties.apiVersion), VK_VERSION_PATCH(devicePoperties.apiVersion));
             }
         }
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDevice.cpp
@@ -451,12 +451,12 @@ namespace clove {
         return Info{
             .ApiName       = "Vulkan",
             .deviceName    = devicePoperties.deviceName,
-            .driverVersion = {
+            .driverVersion = Version{
                 .major = VK_VERSION_MAJOR(devicePoperties.driverVersion),
                 .minor = VK_VERSION_MINOR(devicePoperties.driverVersion),
                 .patch = VK_VERSION_PATCH(devicePoperties.driverVersion),
             },
-            .ApiVersion = {
+            .ApiVersion = Version{
                 .major = VK_VERSION_MAJOR(devicePoperties.apiVersion),
                 .minor = VK_VERSION_MINOR(devicePoperties.apiVersion),
                 .patch = VK_VERSION_PATCH(devicePoperties.apiVersion),

--- a/clove/components/core/platform/source/Linux/LinuxWindow.cpp
+++ b/clove/components/core/platform/source/Linux/LinuxWindow.cpp
@@ -8,7 +8,6 @@ CLOVE_DECLARE_LOG_CATEGORY(ClovePlatformLinux)
 namespace clove {
     LinuxWindow::LinuxWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(ClovePlatformLinux, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
         CLOVE_ASSERT_MSG(window == 0, "Window already exists! Currently only a single window on linux is supported");
 
         if(display == nullptr) {
@@ -52,8 +51,6 @@ namespace clove {
         XMapRaised(display, window);
 
         open = true;
-
-        CLOVE_LOG(ClovePlatformLinux, LogLevel::Trace, "Window created");
     }
 
     LinuxWindow::~LinuxWindow() {

--- a/clove/components/core/platform/source/Mac/MacWindow.mm
+++ b/clove/components/core/platform/source/Mac/MacWindow.mm
@@ -19,8 +19,6 @@ CLOVE_DECLARE_LOG_CATEGORY(ClovePlatformMacOS)
 namespace clove{
     MacWindow::MacWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(ClovePlatformMacOS, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
-
         //Application specific init
         [NSApplication sharedApplication];
         [NSApp finishLaunching];
@@ -53,8 +51,6 @@ namespace clove{
         windowProxy.cloveWindow = this;
         
         open = true;
-
-        CLOVE_LOG(ClovePlatformMacOS, LogLevel::Trace, "Window created");
     }
     
     MacWindow::~MacWindow() = default;

--- a/clove/components/core/platform/source/Windows/WindowsWindow.cpp
+++ b/clove/components/core/platform/source/Windows/WindowsWindow.cpp
@@ -10,8 +10,6 @@ CLOVE_DECLARE_LOG_CATEGORY(ClovePlatformWindows)
 namespace clove {
     WindowsWindow::WindowsWindow(Descriptor const &descriptor)
         : Window(keyboardDispatcher, mouseDispatcher) {
-        CLOVE_LOG(ClovePlatformWindows, LogLevel::Trace, "Creating window: {0} ({1}, {2})", descriptor.title, descriptor.width, descriptor.height);
-
         instance = GetModuleHandle(nullptr);
 
         WNDCLASSEX windowClass {
@@ -28,8 +26,6 @@ namespace clove {
             .lpszClassName = className,
         };
         RegisterClassEx(&windowClass);
-
-        CLOVE_LOG(ClovePlatformWindows, LogLevel::Trace, "Windows class registered");
 
         std::string const wideTitle(descriptor.title.begin(), descriptor.title.end());
 
@@ -57,8 +53,6 @@ namespace clove {
             this);
 
         open = true;
-
-        CLOVE_LOG(ClovePlatformWindows, LogLevel::Trace, "Window created");
     }
 
     WindowsWindow::~WindowsWindow() {

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -1,6 +1,6 @@
 #include <Clove/Log/Log.hpp>
 
-CLOVE_DECLARE_LOG_CATEGORY(CloveApp)
+CLOVE_DECLARE_LOG_CATEGORY(CloveApplication)
 
 namespace clove {
     template<typename SubSystemType, typename... Args>
@@ -17,7 +17,7 @@ namespace clove {
 
         auto subSystem{ std::make_unique<SubSystemType>(std::forward<Args>(args)...) };
 
-        CLOVE_LOG(CloveApp, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
+        CLOVE_LOG(CloveApplication, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
 
         subSystem->onAttach();
         subSystems[group].push_back(std::move(subSystem));
@@ -40,7 +40,7 @@ namespace clove {
         std::type_index const subSystemIndex{ typeid(SubSystemType) };
 
         if(subSystemToIndex.find(subSystemIndex) == subSystemToIndex.end()) {
-            CLOVE_LOG(CloveApp, LogLevel::Warning, "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
+            CLOVE_LOG(CloveApplication, LogLevel::Warning, "{0}: No subsystem of type provided is currently attached.", CLOVE_FUNCTION_NAME_PRETTY);
             return;
         }
 

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -27,24 +27,28 @@ namespace clove {
         }
     }
 
-    std::unique_ptr<Application> Application::create(GraphicsApi graphicsApi, AudioApi audioApi, Window::Descriptor const &windowDescriptor) {	
-		auto window{ Window::create(windowDescriptor) };
-		auto *windowPtr{ window.get() };
-		
-		auto graphicsDevice{ createGraphicsDevice(graphicsApi, window->getNativeWindow()) };
-		auto audioDevice{ createAudioDevice(audioApi) };
-		
-		auto surface{ std::make_unique<WindowSurface>(std::move(window)) };
-		
-		auto renderTarget{ std::make_unique<SwapchainRenderTarget>(*surface, graphicsDevice.get()) };
-		
-		std::unique_ptr<Application> app{ new Application{ std::move(graphicsDevice), std::move(audioDevice), std::move(surface), std::move(renderTarget) } };
-		windowPtr->onWindowCloseDelegate.bind(&Application::shutdown, app.get());
-		
+    std::unique_ptr<Application> Application::create(GraphicsApi graphicsApi, AudioApi audioApi, Window::Descriptor const &windowDescriptor) {
+        CLOVE_LOG(CloveApplication, LogLevel::Info, "Creating windowed application ({0}, {1}).", windowDescriptor.width, windowDescriptor.height);
+
+        auto window{ Window::create(windowDescriptor) };
+        auto *windowPtr{ window.get() };
+
+        auto graphicsDevice{ createGraphicsDevice(graphicsApi, window->getNativeWindow()) };
+        auto audioDevice{ createAudioDevice(audioApi) };
+
+        auto surface{ std::make_unique<WindowSurface>(std::move(window)) };
+
+        auto renderTarget{ std::make_unique<SwapchainRenderTarget>(*surface, graphicsDevice.get()) };
+
+        std::unique_ptr<Application> app{ new Application{ std::move(graphicsDevice), std::move(audioDevice), std::move(surface), std::move(renderTarget) } };
+        windowPtr->onWindowCloseDelegate.bind(&Application::shutdown, app.get());
+
         return app;
     }
 
     std::pair<std::unique_ptr<Application>, GraphicsImageRenderTarget *> Application::createHeadless(GraphicsApi graphicsApi, AudioApi audioApi, GhaImage::Descriptor renderTargetDescriptor, std::unique_ptr<Surface> surface) {
+        CLOVE_LOG(CloveApplication, LogLevel::Info, "Creating headless application.");
+
         auto graphicsDevice{ createGraphicsDevice(graphicsApi, std::any{}) };
         auto audioDevice{ createAudioDevice(audioApi) };
 


### PR DESCRIPTION
## Summary
Added a way to retrieve information about the device from `GhaDevice`. Note that some APIs cannot provide everything.

Closes #387 

## Changes
- Added `GhaDevice::getInfo` to report information about the device itself.