### PR TITLE
Reset unique pointers when freeing descriptor sets

### DIFF
--- a/clove/components/core/graphics/CMakeLists.txt
+++ b/clove/components/core/graphics/CMakeLists.txt
@@ -174,6 +174,8 @@ set(
 		${INCLUDE}/Validation/ValidationCommandBuffer.hpp
 		${INCLUDE}/Validation/ValidationCommandBuffer.inl
 		${SOURCE}/Validation/ValidationCommandBuffer.cpp
+		${INCLUDE}/Validation/ValidationDescriptorPool.hpp
+		${INCLUDE}/Validation/ValidationDescriptorPool.inl
 		${INCLUDE}/Validation/ValidationLog.hpp
 		${INCLUDE}/Validation/ValidationQueue.hpp
 		${INCLUDE}/Validation/ValidationQueue.inl

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDescriptorPool.hpp
@@ -28,13 +28,13 @@ namespace clove {
     public:
         enum class Flag {
             None,
-            FreeDescriptorSet /**< DescriptorSets can be freed individualy. */
+            FreeDescriptorSet /**< DescriptorSets can be freed individualy. Some platforms might use a more simple allocator if this isn't set. */
         };
 
         struct Descriptor {
-            std::vector<DescriptorInfo> poolTypes;
-            Flag flag;
-            uint32_t maxSets; /**< The maximum amount of DescriptorSets that can be allocated from this pool. */
+            std::vector<DescriptorInfo> poolTypes{};
+            Flag flag{ Flag::None };
+            uint32_t maxSets{ 0 }; /**< The maximum amount of DescriptorSets that can be allocated from this pool. */
         };
 
         //FUNCTIONS
@@ -52,14 +52,16 @@ namespace clove {
         /**
          * @brief Free an individual descriptor set. Requires Flag::FreeDescriptorSet to be set on creation.
          */
-        virtual void freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) = 0;
+        virtual void freeDescriptorSets(std::unique_ptr<GhaDescriptorSet> &descriptorSet) = 0;
         /**
          * @brief Frees individual descriptor sets. Requires Flag::FreeDescriptorSet to be set on creation.
          */
-        virtual void freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) = 0;
+        virtual void freeDescriptorSets(std::vector<std::unique_ptr<GhaDescriptorSet>> &descriptorSets) = 0;
 
         /**
-         * @brief Resets this pool freeing all DescriptorSets allocated from it.
+         * @brief Resets this pool interally freeing all DescriptorSets allocated from it.
+         * @details This will only internally reset the descriptor pool and not reset any pointers. 
+         * All sets allocated from this pool will be in an undefined state and must be deleted manually.
          */
         virtual void reset() = 0;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Helpers.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Helpers.inl
@@ -2,6 +2,7 @@
     #include "Clove/Graphics/Validation/ValidationBuffer.hpp"
     #include "Clove/Graphics/Validation/ValidationCommandBuffer.hpp"
     #include "Clove/Graphics/Validation/ValidationQueue.hpp"
+    #include "Clove/Graphics/Validation/ValidationDescriptorPool.hpp"
 
     #include <type_traits>
 #endif
@@ -24,6 +25,8 @@ namespace clove {
             return std::make_unique<ValidationComputeCommandBuffer<GhaObjectType>>(std::forward<Args>(args)...);
         } else if constexpr(std::is_base_of_v<GhaTransferCommandBuffer, GhaObjectType>) {
             return std::make_unique<ValidationTransferCommandBuffer<GhaObjectType>>(std::forward<Args>(args)...);
+        } else if constexpr(std::is_base_of_v<GhaDescriptorPool, GhaObjectType>) {
+            return std::make_unique<ValidationDescriptorPool<GhaObjectType>>(std::forward<Args>(args)...);
         } else {
             return std::make_unique<GhaObjectType>(std::forward<Args>(args)...);
         }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorPool.hpp
@@ -7,6 +7,10 @@
 #include <vector>
 
 namespace clove {
+    class MetalDescriptorSet;
+}
+
+namespace clove {
 	class MetalDescriptorPool : public GhaDescriptorPool {
 		//TYPES
 	private:
@@ -59,9 +63,12 @@ namespace clove {
 		std::unique_ptr<GhaDescriptorSet> allocateDescriptorSets(GhaDescriptorSetLayout const *const layout) override;
 		std::vector<std::unique_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<GhaDescriptorSetLayout const *> const &layouts) override;
 
-		void freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) override;
-		void freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) override;
+        void freeDescriptorSets(std::unique_ptr<GhaDescriptorSet> &descriptorSet) override;
+        void freeDescriptorSets(std::vector<std::unique_ptr<GhaDescriptorSet>> &descriptorSets) override;
 
-		void reset() override;
-	};
+        void reset() override;
+
+	private:
+        void freeBuffers(MetalDescriptorSet &descriptorSet);
+    };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorPool.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Clove/Graphics/GhaDescriptorPool.hpp"
+
+namespace clove {
+    template<typename BasePoolType>
+    class ValidationDescriptorPool : public BasePoolType {
+        //FUNCTIONS
+    public:
+        using BasePoolType::BasePoolType;
+
+        void freeDescriptorSets(std::unique_ptr<GhaDescriptorSet> &descriptorSet) override;
+        void freeDescriptorSets(std::vector<std::unique_ptr<GhaDescriptorSet>> &descriptorSets) override;
+    };
+}
+
+#include "ValidationDescriptorPool.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorPool.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorPool.inl
@@ -1,0 +1,17 @@
+#include <Clove/Log/Log.hpp>
+
+namespace clove {
+    template<typename BasePoolType>
+    void ValidationDescriptorPool<BasePoolType>::freeDescriptorSets(std::unique_ptr<GhaDescriptorSet> &descriptorSet) {
+        CLOVE_ASSERT_MSG(BasePoolType::getDescriptor().flag == GhaDescriptorPool::Flag::FreeDescriptorSet, "{0}: Cannot manually free descriptor sets from a pool created without GhaDescriptorPool::Flag::FreeDescriptorSet", CLOVE_FUNCTION_NAME_PRETTY);
+
+        BasePoolType::freeDescriptorSets(descriptorSet);
+    }
+
+    template<typename BasePoolType>
+    void ValidationDescriptorPool<BasePoolType>::freeDescriptorSets(std::vector<std::unique_ptr<GhaDescriptorSet>> &descriptorSets) {
+        CLOVE_ASSERT_MSG(BasePoolType::getDescriptor().flag == GhaDescriptorPool::Flag::FreeDescriptorSet, "{0}: Cannot manually free descriptor sets from a pool created without GhaDescriptorPool::Flag::FreeDescriptorSet", CLOVE_FUNCTION_NAME_PRETTY);
+
+        BasePoolType::freeDescriptorSets(descriptorSets);
+    }
+}

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDescriptorPool.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDescriptorPool.hpp
@@ -33,8 +33,8 @@ namespace clove {
         std::unique_ptr<GhaDescriptorSet> allocateDescriptorSets(GhaDescriptorSetLayout const *const layout) override;
         std::vector<std::unique_ptr<GhaDescriptorSet>> allocateDescriptorSets(std::vector<GhaDescriptorSetLayout const *> const &layouts) override;
 
-        void freeDescriptorSets(GhaDescriptorSet const *const descriptorSet) override;
-        void freeDescriptorSets(std::vector<GhaDescriptorSet const *> const &descriptorSets) override;
+        void freeDescriptorSets(std::unique_ptr<GhaDescriptorSet> &descriptorSet) override;
+        void freeDescriptorSets(std::vector<std::unique_ptr<GhaDescriptorSet>> &descriptorSets) override;
 
         void reset() override;
     };


### PR DESCRIPTION
## Summary
When freeing individual descriptor sets the `unique_ptr`s passed to the function are now reset, leaving them `nullptr` instead of in an undefined state. Calling `GhaDescriptorPool::reset` does still have this problem however.

## Changes
- `freeDescriptorSets` now resets the `unique_ptr`(s) passed to it.
- Added validation for `GhaDescriptorPool::freeDescriptorSets`
