### PR TITLE
`AnimatedModelComponent` now uses `AssetPtr`

### DIFF
--- a/clove/include/Clove/Components/AnimatedModelComponent.hpp
+++ b/clove/include/Clove/Components/AnimatedModelComponent.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "Clove/Rendering/Animator.hpp"
 #include "Clove/Rendering/Material.hpp"
 #include "Clove/Rendering/Renderables/AnimatedModel.hpp"
 
 namespace clove {
     struct AnimatedModelComponent {
-        AnimatedModel model;
+        AssetPtr<AnimatedModel> model;
         std::shared_ptr<Material> material{ std::make_shared<Material>() };
+        Animator animator;
     };
 }

--- a/clove/include/Clove/Rendering/Renderables/AnimatedModel.hpp
+++ b/clove/include/Clove/Rendering/Renderables/AnimatedModel.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Clove/Rendering/AnimationTypes.hpp"
-#include "Clove/Rendering/Animator.hpp"
 #include "Clove/Rendering/Renderables/StaticModel.hpp"
 
 #include <Clove/Maths/Vector.hpp>
@@ -16,8 +15,6 @@ namespace clove {
     class AnimatedModel : public StaticModel {
         //VARIABLES
     private:
-        Animator animator;
-
         std::unique_ptr<Skeleton> skeleton;
         std::vector<AnimationClip> animClips;
 
@@ -34,12 +31,7 @@ namespace clove {
 
         ~AnimatedModel();
 
-        /**
-         * @brief Updates the internal animator.
-         * @param deltaTime The time since the last frame
-         * @returns The matrix palette for the skeleton for a given frame
-         */
-        inline std::array<mat4f, MAX_JOINTS> update(DeltaTime const deltaTime);
+        inline std::vector<AnimationClip> const &getAnimationClips() const;
     };
 }
 

--- a/clove/include/Clove/Rendering/Renderables/AnimatedModel.inl
+++ b/clove/include/Clove/Rendering/Renderables/AnimatedModel.inl
@@ -1,5 +1,5 @@
 namespace clove {
-    std::array<mat4f, MAX_JOINTS> AnimatedModel::update(DeltaTime const deltaTime) {
-        return animator.update(deltaTime);
+    std::vector<AnimationClip> const &AnimatedModel::getAnimationClips() const {
+        return animClips;
     }
 }

--- a/clove/source/Rendering/Renderables/AnimatedModel.cpp
+++ b/clove/source/Rendering/Renderables/AnimatedModel.cpp
@@ -1,7 +1,7 @@
 #include "Clove/Rendering/Renderables/AnimatedModel.hpp"
 
-#include "Clove/Rendering/Techniques/ForwardLightingTechnique.hpp"
 #include "Clove/Rendering/RenderingLog.hpp"
+#include "Clove/Rendering/Techniques/ForwardLightingTechnique.hpp"
 
 #include <Clove/Log/Log.hpp>
 
@@ -12,31 +12,26 @@ namespace clove {
         , animClips{ std::move(animClips) } {
         if(this->animClips.empty()) {
             CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
-        } else {
-            animator.setCurrentClip(&this->animClips[0]);
         }
     }
 
     AnimatedModel::AnimatedModel(AnimatedModel const &other)
-        : StaticModel(other)
-        , skeleton(std::make_unique<Skeleton>(*other.skeleton))
-        , animClips(other.animClips) {
+        : StaticModel{ other }
+        , skeleton{ std::make_unique<Skeleton>(*other.skeleton) }
+        , animClips{ other.animClips } {
         for(auto &clip : animClips) {
             clip.skeleton = skeleton.get();
         }
 
         if(this->animClips.empty()) {
             CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
-        } else {
-            animator.setCurrentClip(&animClips[0]);
         }
     }
 
     AnimatedModel::AnimatedModel(AnimatedModel &&other) noexcept
-        : StaticModel(std::move(other))
-        , animator(std::move(other.animator))
-        , skeleton(std::move(other.skeleton))
-        , animClips(std::move(other.animClips)) {
+        : StaticModel{ std::move(other) }
+        , skeleton{ std::move(other.skeleton) }
+        , animClips{ std::move(other.animClips) } {
     }
 
     AnimatedModel &AnimatedModel::operator=(AnimatedModel const &other) {
@@ -50,8 +45,6 @@ namespace clove {
 
         if(std::size(animClips) == 0) {
             CLOVE_LOG(CloveRendering, LogLevel::Warning, "AnimatedModel initialised without any animation clips. Won't be able to play animations");
-        } else {
-            animator.setCurrentClip(&animClips[0]);
         }
 
         return *this;
@@ -59,7 +52,6 @@ namespace clove {
 
     AnimatedModel &AnimatedModel::operator=(AnimatedModel &&other) noexcept {
         StaticModel::operator=(std::move(other));
-        animator             = std::move(other.animator);
         skeleton             = std::move(other.skeleton);
         animClips            = std::move(other.animClips);
 

--- a/clove/source/SubSystems/RenderSubSystem.cpp
+++ b/clove/source/SubSystems/RenderSubSystem.cpp
@@ -48,11 +48,11 @@ namespace clove {
 
         //Submit static meshes
         entityManager->forEach([this](TransformComponent const &transform, StaticModelComponent const &staticModel) {
-            mat4f const modelTransform{ transform.worldMatrix };
-            std::array<mat4f, MAX_JOINTS> matrixPalet{};
-            matrixPalet.fill(mat4f{ 1.0f });
-
             if(staticModel.model.isValid()) {
+                mat4f const modelTransform{ transform.worldMatrix };
+                std::array<mat4f, MAX_JOINTS> matrixPalet{};
+                matrixPalet.fill(mat4f{ 1.0f });
+
                 std::set<GeometryPass::Id> passIds;
                 for(auto const &technique : staticModel.model->getTechniques()) {
                     passIds.insert(technique.passIds.begin(), technique.passIds.end());
@@ -64,15 +64,17 @@ namespace clove {
         });
         //Submit animated meshes
         entityManager->forEach([this, &deltaTime](TransformComponent const &transform, AnimatedModelComponent &animatedModel) {
-            mat4f const modelTransform{ transform.worldMatrix };
-            auto const matrixPalet{ animatedModel.model.update(deltaTime) };
+            if(animatedModel.model.isValid()) {
+                mat4f const modelTransform{ transform.worldMatrix };
+                auto const matrixPalet{ animatedModel.animator.update(deltaTime) };
 
-            std::set<GeometryPass::Id> passIds;
-            for(auto const &technique : animatedModel.model.getTechniques()) {
-                passIds.insert(technique.passIds.begin(), technique.passIds.end());
-            }
-            for(auto const &mesh : animatedModel.model.getMeshes()) {
-                renderer->submitMesh(ForwardRenderer3D::MeshInfo{ mesh, animatedModel.material, modelTransform, matrixPalet }, passIds);
+                std::set<GeometryPass::Id> passIds;
+                for(auto const &technique : animatedModel.model->getTechniques()) {
+                    passIds.insert(technique.passIds.begin(), technique.passIds.end());
+                }
+                for(auto const &mesh : animatedModel.model->getMeshes()) {
+                    renderer->submitMesh(ForwardRenderer3D::MeshInfo{ mesh, animatedModel.material, modelTransform, matrixPalet }, passIds);
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
To achieve this this `Animator` was moved out of the `AnimatedModel` class itself. This will make it so that more than one component can point to the same model without update it's state for all components

Closes #347 

## Changes
- `AnimatedModelComponent` now uses `AssetPtr`