### PR TITLE
Removed the dereference operators from `Expected`

### DIFF
--- a/clove/components/systems/serialisation/tests/YamlDeserialisationTests.cpp
+++ b/clove/components/systems/serialisation/tests/YamlDeserialisationTests.cpp
@@ -56,7 +56,7 @@ protected:
 };
 
 TEST_F(YamlDeserialisationTests, CanLoadSimpleValueFromFile) {
-    Node file{ *loadYaml("TestFile.yaml") };
+    Node file{ loadYaml("TestFile.yaml").getValue() };
 
     EXPECT_EQ(file["IntValue"].as<int32_t>(), 3);
     EXPECT_EQ(file["FloatValue"].as<float>(), 4.5f);
@@ -64,14 +64,14 @@ TEST_F(YamlDeserialisationTests, CanLoadSimpleValueFromFile) {
 }
 
 TEST_F(YamlDeserialisationTests, CanLoadNestedValuesFromParentNodes) {
-    Node file{ *loadYaml("TestFile.yaml") };
+    Node file{ loadYaml("TestFile.yaml").getValue() };
 
     EXPECT_EQ(file["Parent"]["ChildOne"].as<int32_t>(), 1);
     EXPECT_EQ(file["Parent"]["ChildTwo"]["Value"].as<int32_t>(), 8);
 }
 
 TEST_F(YamlDeserialisationTests, CannotGetIncorrectType) {
-    Node file{ *loadYaml("TestFile.yaml") };
+    Node file{ loadYaml("TestFile.yaml").getValue() };
 
     EXPECT_ANY_THROW(file["TestType"].as<std::string>());
 }
@@ -121,7 +121,7 @@ namespace clove {
 }
 
 TEST_F(YamlDeserialisationTests, CanLoadSerialisableTypeFromFile) {
-    Node file{ *loadYaml("TestFile.yaml") };
+    Node file{ loadYaml("TestFile.yaml").getValue() };
 
     auto type{ file["TestType"].as<BasicSerialisableType>() };
 
@@ -153,7 +153,7 @@ namespace clove {
 }
 
 TEST_F(YamlDeserialisationTests, CanLoadSerialisableParentTypeFromFile) {
-    Node file{ *loadYaml("TestFile.yaml") };
+    Node file{ loadYaml("TestFile.yaml").getValue() };
 
     auto type{ file["TestParentType"].as<ParentSerialisableType>() };
 
@@ -163,7 +163,7 @@ TEST_F(YamlDeserialisationTests, CanLoadSerialisableParentTypeFromFile) {
 }
 
 TEST_F(YamlDeserialisationTests, CanLoadASequenceFromFile) {
-    Node file{ *loadYaml("TestFile.yaml") };
+    Node file{ loadYaml("TestFile.yaml").getValue() };
 
     Node sequence{ file["TestSequence"] };
     for(size_t index{ 0 }; Node &child : sequence){

--- a/clove/components/utilities/expected/include/Clove/Expected.hpp
+++ b/clove/components/utilities/expected/include/Clove/Expected.hpp
@@ -78,14 +78,6 @@ namespace clove {
         T &&getValue() &&;
         T const &&getValue() const &&;
 
-        T *operator->();
-        T const *operator->() const;
-
-        T &operator*() &;
-        T const &operator*() const &;
-        T &&operator*() &&;
-        T const &&operator*() const &&;
-
         /**
          * @brief Returns the contained error. If this contains a value 'assert' is called instead.
          */

--- a/clove/components/utilities/expected/include/Clove/Expected.inl
+++ b/clove/components/utilities/expected/include/Clove/Expected.inl
@@ -110,42 +110,6 @@ namespace clove {
     }
 
     template<typename T, typename E>
-    T *Expected<T, E>::operator->() {
-        if(!ok) {
-            throw error;
-        }
-        return &value;
-    }
-
-    template<typename T, typename E>
-    T const *Expected<T, E>::operator->() const {
-        if(!ok) {
-            throw error;
-        }
-        return &value;
-    }
-
-    template<typename T, typename E>
-    T &Expected<T, E>::operator*() & {
-        return getValue();
-    }
-
-    template<typename T, typename E>
-    T const &Expected<T, E>::operator*() const & {
-        return getValue();
-    }
-
-    template<typename T, typename E>
-    T &&Expected<T, E>::operator*() && {
-        return std::move(getValue());
-    }
-
-    template<typename T, typename E>
-    T const &&Expected<T, E>::operator*() const && {
-        return std::move(getValue());
-    }
-
-    template<typename T, typename E>
     E &Expected<T, E>::getError() & {
         assert(!ok);
         return error;

--- a/clove/components/utilities/expected/tests/ExpectedTests.cpp
+++ b/clove/components/utilities/expected/tests/ExpectedTests.cpp
@@ -8,7 +8,6 @@ TEST(ExpectedTests, CanConstructWithAValue) {
     Expected<int32_t, std::exception> expectedValue(testValue);
 
     EXPECT_EQ(testValue, expectedValue.getValue());
-    EXPECT_EQ(testValue, *expectedValue);
 }
 
 TEST(ExpectedTests, CanConstructWithAnError) {
@@ -48,7 +47,7 @@ TEST(ExpectedTests, CallsDestructorOnValueType) {
     bool destructorCalled{ false };
 
     {
-        Expected<Helper, std::exception> expected(Helper{ destructorCalled });
+        Expected<Helper, std::exception> expected{ Helper{ destructorCalled } };
     }
 
     EXPECT_TRUE(destructorCalled);
@@ -71,7 +70,7 @@ TEST(ExpectedTests, CallsDestructorOnErrorType) {
     bool destructorCalled{ false };
 
     {
-        Expected<int32_t, Helper> expected(Unexpected<Helper>{ Helper{ destructorCalled } });
+        Expected<int32_t, Helper> expected{ Unexpected<Helper>{ Helper{ destructorCalled } } };
     }
 
     EXPECT_TRUE(destructorCalled);
@@ -160,7 +159,7 @@ TEST(ExpectedTests, MovesValueWhenIsAnRRef) {
     };
 
     Expected<Helper, std::exception> expected{ Helper{} };
-    Helper helper = std::move(expected.getValue());
+    Helper helper{ std::move(expected.getValue()) };
 
     EXPECT_FALSE(helper.copied);
 }
@@ -186,7 +185,7 @@ TEST(ExpectedTests, MovesErrorWhenIsAnRRef) {
     };
 
     Expected<std::string, Helper> expected{ Helper{} };
-    Helper helper = std::move(expected.getError());
+    Helper helper{ std::move(expected.getError()) };
 
     EXPECT_FALSE(helper.copied);
 }
@@ -230,11 +229,11 @@ TEST(ExpectedTests, CanReturnProperlyFromAFunction) {
         }
     };
 
-    ExpectedReturner helper;
+    ExpectedReturner helper{};
 
-    auto value                 = helper.return42();
-    auto error                 = helper.returnException();
-    NotCopyable notCopyableObj = helper.returnNonCopyable().getValue();
+    auto value{ helper.return42() };
+    auto error{ helper.returnException() };
+    NotCopyable notCopyableObj{ helper.returnNonCopyable().getValue() };
 
     EXPECT_TRUE(value.hasValue());
     EXPECT_FALSE(error.hasValue());

--- a/clove/source/Rendering/GraphicsImageRenderTarget.cpp
+++ b/clove/source/Rendering/GraphicsImageRenderTarget.cpp
@@ -14,11 +14,11 @@ namespace clove {
         , factory{ factory } {
 
         //We won't be allocating any buffers from this queue, only using it to submit
-        graphicsQueue = *this->factory->createGraphicsQueue(CommandQueueDescriptor{ .flags = QueueFlags::None });
-        transferQueue = *this->factory->createTransferQueue(CommandQueueDescriptor{ .flags = QueueFlags::ReuseBuffers });
+        graphicsQueue = this->factory->createGraphicsQueue(CommandQueueDescriptor{ .flags = QueueFlags::None }).getValue();
+        transferQueue = this->factory->createTransferQueue(CommandQueueDescriptor{ .flags = QueueFlags::ReuseBuffers }).getValue();
 
-        frameInFlight           = *this->factory->createFence({ true });
-        renderFinishedSemaphore = *this->factory->createSemaphore();
+        frameInFlight           = this->factory->createFence({ true }).getValue();
+        renderFinishedSemaphore = this->factory->createSemaphore().getValue();
 
         transferCommandBuffer = transferQueue->allocateCommandBuffer();
 
@@ -89,7 +89,7 @@ namespace clove {
 
         onPropertiesChangedBegin.broadcast();
 
-        renderTargetImage = *factory->createImage(imageDescriptor);
+        renderTargetImage = factory->createImage(imageDescriptor).getValue();
         renderTargetView  = renderTargetImage->createView(GhaImageView::Descriptor{
             .type       = GhaImageView::Type::_2D,
             .layer      = 0,
@@ -98,12 +98,13 @@ namespace clove {
 
         size_t constexpr bytesPerPixel{ 4 };//Assuming image format is 4 bbp
         size_t const bufferSize{ imageDescriptor.dimensions.x * imageDescriptor.dimensions.y * bytesPerPixel };
-        renderTargetBuffer = *factory->createBuffer(GhaBuffer::Descriptor{
-            .size        = bufferSize,
-            .usageFlags  = GhaBuffer::UsageMode::TransferDestination,
-            .sharingMode = SharingMode::Exclusive,
-            .memoryType  = MemoryType::SystemMemory,
-        });
+        renderTargetBuffer = factory->createBuffer(GhaBuffer::Descriptor{
+                                                       .size        = bufferSize,
+                                                       .usageFlags  = GhaBuffer::UsageMode::TransferDestination,
+                                                       .sharingMode = SharingMode::Exclusive,
+                                                       .memoryType  = MemoryType::SystemMemory,
+                                                   })
+                                 .getValue();
 
         //Pre-record the transfer command
         ImageMemoryBarrierInfo constexpr layoutTransferInfo{

--- a/clove/source/Rendering/RenderPasses/DirectionalLightPass.cpp
+++ b/clove/source/Rendering/RenderPasses/DirectionalLightPass.cpp
@@ -42,27 +42,28 @@ namespace clove {
             .size     = { shadowMapSize, shadowMapSize }
         };
 
-        auto vertShader{ *ghaFactory.createShaderFromSource({ meshshadowmap_v, meshshadowmap_vLength }, shaderIncludes, "Shadow Map - Animated Mesh (vertex)", GhaShader::Stage::Vertex) };
-        auto pixelShader{ *ghaFactory.createShaderFromSource({ meshshadowmap_p, meshshadowmap_pLength }, shaderIncludes, "Shadow Map (pixel)", GhaShader::Stage::Pixel) };
+        auto vertShader{ ghaFactory.createShaderFromSource({ meshshadowmap_v, meshshadowmap_vLength }, shaderIncludes, "Shadow Map - Animated Mesh (vertex)", GhaShader::Stage::Vertex).getValue() };
+        auto pixelShader{ ghaFactory.createShaderFromSource({ meshshadowmap_p, meshshadowmap_pLength }, shaderIncludes, "Shadow Map (pixel)", GhaShader::Stage::Pixel).getValue() };
 
         auto meshLayout{ createMeshDescriptorSetLayout(ghaFactory) };
 
-        pipeline = *ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
-            .vertexShader         = vertShader.get(),
-            .pixelShader          = pixelShader.get(),
-            .vertexInput          = Vertex::getInputBindingDescriptor(),
-            .vertexAttributes     = vertexAttributes,
-            .viewportDescriptor   = viewScissorArea,
-            .scissorDescriptor    = viewScissorArea,
-            .enableBlending       = false,
-            .renderPass           = ghaRenderPass,
-            .descriptorSetLayouts = {
-                meshLayout.get(),
-            },
-            .pushConstants = {
-                pushConstant,
-            },
-        });
+        pipeline = ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
+                                                               .vertexShader         = vertShader.get(),
+                                                               .pixelShader          = pixelShader.get(),
+                                                               .vertexInput          = Vertex::getInputBindingDescriptor(),
+                                                               .vertexAttributes     = vertexAttributes,
+                                                               .viewportDescriptor   = viewScissorArea,
+                                                               .scissorDescriptor    = viewScissorArea,
+                                                               .enableBlending       = false,
+                                                               .renderPass           = ghaRenderPass,
+                                                               .descriptorSetLayouts = {
+                                                                   meshLayout.get(),
+                                                               },
+                                                               .pushConstants = {
+                                                                   pushConstant,
+                                                               },
+                                                           })
+                       .getValue();
     }
 
     DirectionalLightPass::DirectionalLightPass(DirectionalLightPass &&other) noexcept = default;

--- a/clove/source/Rendering/RenderPasses/ForwardColourPass.cpp
+++ b/clove/source/Rendering/RenderPasses/ForwardColourPass.cpp
@@ -47,28 +47,29 @@ namespace clove {
             .state = ElementState::Dynamic,
         };
 
-        auto vertShader{ *ghaFactory.createShaderFromSource({ mesh_v, mesh_vLength }, shaderIncludes, "Animated Mesh (vertex)", GhaShader::Stage::Vertex) };
-        auto pixelShader{ *ghaFactory.createShaderFromSource({ mesh_p, mesh_pLength }, shaderIncludes, "Mesh (pixel)", GhaShader::Stage::Pixel) };
+        auto vertShader{ ghaFactory.createShaderFromSource({ mesh_v, mesh_vLength }, shaderIncludes, "Animated Mesh (vertex)", GhaShader::Stage::Vertex).getValue() };
+        auto pixelShader{ ghaFactory.createShaderFromSource({ mesh_p, mesh_pLength }, shaderIncludes, "Mesh (pixel)", GhaShader::Stage::Pixel).getValue() };
 
         auto meshLayout{ createMeshDescriptorSetLayout(ghaFactory) };
         auto viewLayout{ createViewDescriptorSetLayout(ghaFactory) };
         auto lightLayout{ createLightingDescriptorSetLayout(ghaFactory) };
 
-        pipeline = *ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
-            .vertexShader         = vertShader.get(),
-            .pixelShader          = pixelShader.get(),
-            .vertexInput          = Vertex::getInputBindingDescriptor(),
-            .vertexAttributes     = vertexAttributes,
-            .viewportDescriptor   = viewScissorArea,
-            .scissorDescriptor    = viewScissorArea,
-            .renderPass           = ghaRenderPass,
-            .descriptorSetLayouts = {
-                meshLayout.get(),
-                viewLayout.get(),
-                lightLayout.get(),
-            },
-            .pushConstants = {},
-        });
+        pipeline = ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
+                                                               .vertexShader         = vertShader.get(),
+                                                               .pixelShader          = pixelShader.get(),
+                                                               .vertexInput          = Vertex::getInputBindingDescriptor(),
+                                                               .vertexAttributes     = vertexAttributes,
+                                                               .viewportDescriptor   = viewScissorArea,
+                                                               .scissorDescriptor    = viewScissorArea,
+                                                               .renderPass           = ghaRenderPass,
+                                                               .descriptorSetLayouts = {
+                                                                   meshLayout.get(),
+                                                                   viewLayout.get(),
+                                                                   lightLayout.get(),
+                                                               },
+                                                               .pushConstants = {},
+                                                           })
+                       .getValue();
     }
 
     ForwardColourPass::ForwardColourPass(ForwardColourPass &&other) noexcept = default;

--- a/clove/source/Rendering/RenderPasses/PointLightPass.cpp
+++ b/clove/source/Rendering/RenderPasses/PointLightPass.cpp
@@ -48,28 +48,29 @@ namespace clove {
             .size     = { shadowMapSize, shadowMapSize }
         };
 
-        auto vertShader{ *ghaFactory.createShaderFromSource({ meshcubeshadowmap_v, meshcubeshadowmap_vLength }, shaderIncludes, "Cube Shadow Map - Animated Mesh (vertex)", GhaShader::Stage::Vertex) };
-        auto pixelShader{ *ghaFactory.createShaderFromSource({ meshcubeshadowmap_p, meshcubeshadowmap_pLength }, shaderIncludes, "Cube Shadow Map (pixel)", GhaShader::Stage::Pixel) };
+        auto vertShader{ ghaFactory.createShaderFromSource({ meshcubeshadowmap_v, meshcubeshadowmap_vLength }, shaderIncludes, "Cube Shadow Map - Animated Mesh (vertex)", GhaShader::Stage::Vertex).getValue() };
+        auto pixelShader{ ghaFactory.createShaderFromSource({ meshcubeshadowmap_p, meshcubeshadowmap_pLength }, shaderIncludes, "Cube Shadow Map (pixel)", GhaShader::Stage::Pixel).getValue() };
 
         auto meshLayout{ createMeshDescriptorSetLayout(ghaFactory) };
 
-        pipeline = *ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
-            .vertexShader         = vertShader.get(),
-            .pixelShader          = pixelShader.get(),
-            .vertexInput          = Vertex::getInputBindingDescriptor(),
-            .vertexAttributes     = vertexAttributes,
-            .viewportDescriptor   = viewScissorArea,
-            .scissorDescriptor    = viewScissorArea,
-            .enableBlending       = false,
-            .renderPass           = ghaRenderPass,
-            .descriptorSetLayouts = {
-                meshLayout.get(),
-            },
-            .pushConstants = {
-                vertexPushConstant,
-                pixelPushConstant,
-            },
-        });
+        pipeline = ghaFactory.createGraphicsPipelineObject(GhaGraphicsPipelineObject::Descriptor{
+                                                               .vertexShader         = vertShader.get(),
+                                                               .pixelShader          = pixelShader.get(),
+                                                               .vertexInput          = Vertex::getInputBindingDescriptor(),
+                                                               .vertexAttributes     = vertexAttributes,
+                                                               .viewportDescriptor   = viewScissorArea,
+                                                               .scissorDescriptor    = viewScissorArea,
+                                                               .enableBlending       = false,
+                                                               .renderPass           = ghaRenderPass,
+                                                               .descriptorSetLayouts = {
+                                                                   meshLayout.get(),
+                                                               },
+                                                               .pushConstants = {
+                                                                   vertexPushConstant,
+                                                                   pixelPushConstant,
+                                                               },
+                                                           })
+                       .getValue();
     }
 
     PointLightPass::PointLightPass(PointLightPass &&other) noexcept = default;

--- a/clove/source/Rendering/RenderPasses/SkinningPass.cpp
+++ b/clove/source/Rendering/RenderPasses/SkinningPass.cpp
@@ -1,7 +1,7 @@
 #include "Clove/Rendering/RenderPasses/SkinningPass.hpp"
 
-#include "Clove/Rendering/RenderingHelpers.hpp"
 #include "Clove/Rendering/Renderables/Mesh.hpp"
+#include "Clove/Rendering/RenderingHelpers.hpp"
 
 #include <Clove/Graphics/GhaComputePipelineObject.hpp>
 #include <Clove/Graphics/GhaDescriptorSetLayout.hpp>
@@ -20,26 +20,25 @@ namespace clove {
         shaderIncludes["Constants.glsl"] = { constants, constantsLength };
 
         //Create pipeline
-		PushConstantDescriptor const pushConstant{
-			.stage = GhaShader::Stage::Compute,
-			.size  = sizeof(size_t),
-		};
+        PushConstantDescriptor const pushConstant{
+            .stage = GhaShader::Stage::Compute,
+            .size  = sizeof(size_t),
+        };
 
-        auto shader{ *ghaFactory.createShaderFromSource({ skinning_c, skinning_cLength }, shaderIncludes, "Skinning (compute)", GhaShader::Stage::Compute) };
+        auto shader{ ghaFactory.createShaderFromSource({ skinning_c, skinning_cLength }, shaderIncludes, "Skinning (compute)", GhaShader::Stage::Compute).getValue() };
 
         auto skinningLayout{ createSkinningDescriptorSetLayout(ghaFactory) };
 
-        GhaComputePipelineObject::Descriptor const skinningPipelineDescriptor{
-            .shader               = shader.get(),
-            .descriptorSetLayouts = {
-                skinningLayout.get(),
-            },
-            .pushConstants = {
-                pushConstant,
-            },
-        };
-
-        pipeline = *ghaFactory.createComputePipelineObject(skinningPipelineDescriptor);
+        pipeline = ghaFactory.createComputePipelineObject(GhaComputePipelineObject::Descriptor{
+                                                              .shader               = shader.get(),
+                                                              .descriptorSetLayouts = {
+                                                                  skinningLayout.get(),
+                                                              },
+                                                              .pushConstants = {
+                                                                  pushConstant,
+                                                              },
+                                                          })
+                       .getValue();
     }
 
     SkinningPass::SkinningPass(SkinningPass &&other) noexcept = default;
@@ -52,10 +51,10 @@ namespace clove {
         commandBuffer.bindPipelineObject(*pipeline);
 
         for(auto const &job : getJobs()) {
-			size_t const pushConstantData{ job.mesh->getVertexCount() };
-			size_t const pushConstantSize{ sizeof(size_t) };
+            size_t const pushConstantData{ job.mesh->getVertexCount() };
+            size_t const pushConstantSize{ sizeof(size_t) };
 
-			commandBuffer.pushConstant(0, pushConstantSize, &pushConstantData);
+            commandBuffer.pushConstant(0, pushConstantSize, &pushConstantData);
             commandBuffer.bindDescriptorSet(*frameData.skinningMeshSets[job.meshDescriptorIndex], 0);
             commandBuffer.disptach({ (job.mesh->getVertexCount() / AVERAGE_WORK_GROUP_SIZE) + 1, 1, 1 });
         }

--- a/clove/source/Rendering/Renderables/Mesh.cpp
+++ b/clove/source/Rendering/Renderables/Mesh.cpp
@@ -10,14 +10,14 @@ namespace clove {
         void copyFullBuffer(GhaBuffer &source, GhaBuffer &dest, size_t const size) {
             GhaFactory &factory{ *Application::get().getGraphicsDevice()->getGraphicsFactory() };
 
-            auto transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
+            auto transferQueue{ factory.createTransferQueue({ QueueFlags::Transient }).getValue() };
             auto transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
 
             transferCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
             transferCommandBuffer->copyBufferToBuffer(source, 0, dest, 0, size);
             transferCommandBuffer->endRecording();
 
-            auto transferQueueFinishedFence{ *factory.createFence({ false }) };
+            auto transferQueueFinishedFence{ factory.createFence({ false }).getValue() };
 
             transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
 
@@ -38,32 +38,35 @@ namespace clove {
         vertexOffset = 0;
         indexOffset  = vertexBufferSize;
 
-        std::unique_ptr<GhaTransferQueue> transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
+        std::unique_ptr<GhaTransferQueue> transferQueue{ factory.createTransferQueue({ QueueFlags::Transient }).getValue() };
         std::unique_ptr<GhaTransferCommandBuffer> transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
 
         //Staging buffer
-        auto stagingBuffer{ *factory.createBuffer(GhaBuffer::Descriptor{
-            .size        = totalSize,
-            .usageFlags  = GhaBuffer::UsageMode::TransferSource,
-            .sharingMode = SharingMode::Exclusive,
-            .memoryType  = MemoryType::SystemMemory,
-        }) };
+        auto stagingBuffer{ factory.createBuffer(GhaBuffer::Descriptor{
+                                                     .size        = totalSize,
+                                                     .usageFlags  = GhaBuffer::UsageMode::TransferSource,
+                                                     .sharingMode = SharingMode::Exclusive,
+                                                     .memoryType  = MemoryType::SystemMemory,
+                                                 })
+                                .getValue() };
 
         //VertexBuffer
-        vertexBuffer = *factory.createBuffer(GhaBuffer::Descriptor{
-            .size        = vertexBufferSize,
-            .usageFlags  = GhaBuffer::UsageMode::TransferDestination | GhaBuffer::UsageMode::StorageBuffer | GhaBuffer::UsageMode::VertexBuffer,
-            .sharingMode = SharingMode::Concurrent,
-            .memoryType  = MemoryType::VideoMemory,
-        });
+        vertexBuffer = factory.createBuffer(GhaBuffer::Descriptor{
+                                                .size        = vertexBufferSize,
+                                                .usageFlags  = GhaBuffer::UsageMode::TransferDestination | GhaBuffer::UsageMode::StorageBuffer | GhaBuffer::UsageMode::VertexBuffer,
+                                                .sharingMode = SharingMode::Concurrent,
+                                                .memoryType  = MemoryType::VideoMemory,
+                                            })
+                           .getValue();
 
         //Combined Buffer
-        combinedBuffer = *factory.createBuffer(GhaBuffer::Descriptor{
-            .size        = totalSize,
-            .usageFlags  = GhaBuffer::UsageMode::TransferSource | GhaBuffer::UsageMode::TransferDestination | GhaBuffer::UsageMode::StorageBuffer | GhaBuffer::UsageMode::VertexBuffer | GhaBuffer::UsageMode::IndexBuffer,
-            .sharingMode = SharingMode::Concurrent,
-            .memoryType  = MemoryType::VideoMemory,
-        });
+        combinedBuffer = factory.createBuffer(GhaBuffer::Descriptor{
+                                                  .size        = totalSize,
+                                                  .usageFlags  = GhaBuffer::UsageMode::TransferSource | GhaBuffer::UsageMode::TransferDestination | GhaBuffer::UsageMode::StorageBuffer | GhaBuffer::UsageMode::VertexBuffer | GhaBuffer::UsageMode::IndexBuffer,
+                                                  .sharingMode = SharingMode::Concurrent,
+                                                  .memoryType  = MemoryType::VideoMemory,
+                                              })
+                             .getValue();
 
         //Map the data into system memory
         stagingBuffer->write(this->vertices.data(), vertexOffset, vertexBufferSize);
@@ -75,7 +78,7 @@ namespace clove {
         transferCommandBuffer->copyBufferToBuffer(*stagingBuffer, 0, *combinedBuffer, 0, totalSize);
         transferCommandBuffer->endRecording();
 
-        auto transferQueueFinishedFence{ *factory.createFence({ false }) };
+        auto transferQueueFinishedFence{ factory.createFence({ false }).getValue() };
 
         transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
 

--- a/clove/source/Rendering/RenderingHelpers.cpp
+++ b/clove/source/Rendering/RenderingHelpers.cpp
@@ -48,15 +48,16 @@ namespace clove {
             .stage     = GhaShader::Stage::Pixel,
         };
 
-        return *factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
-            .bindings = {
-                modelBinding,
-                diffuseTextureBinding,
-                specularTextureBinding,
-                samplerBinding,
-                colourBinding,
-            },
-        });
+        return factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
+                                                     .bindings = {
+                                                         modelBinding,
+                                                         diffuseTextureBinding,
+                                                         specularTextureBinding,
+                                                         samplerBinding,
+                                                         colourBinding,
+                                                     },
+                                                 })
+            .getValue();
     }
 
     std::unique_ptr<GhaDescriptorSetLayout> createViewDescriptorSetLayout(GhaFactory &factory) {
@@ -74,12 +75,13 @@ namespace clove {
             .stage     = GhaShader::Stage::Pixel,
         };
 
-        return *factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
-            .bindings = {
-                viewDataBinding,
-                viewPosBinding,
-            },
-        });
+        return factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
+                                                     .bindings = {
+                                                         viewDataBinding,
+                                                         viewPosBinding,
+                                                     },
+                                                 })
+            .getValue();
     }
 
     std::unique_ptr<GhaDescriptorSetLayout> createLightingDescriptorSetLayout(GhaFactory &factory) {
@@ -125,16 +127,17 @@ namespace clove {
             .stage     = GhaShader::Stage::Pixel,
         };
 
-        return *factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
-            .bindings = {
-                lightDataBinding,
-                numLightBinding,
-                directionalShadowTransformBinding,
-                directionalShadowMapBinding,
-                pointShadowMapBinding,
-                samplerBinding,
-            },
-        });
+        return factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
+                                                     .bindings = {
+                                                         lightDataBinding,
+                                                         numLightBinding,
+                                                         directionalShadowTransformBinding,
+                                                         directionalShadowMapBinding,
+                                                         pointShadowMapBinding,
+                                                         samplerBinding,
+                                                     },
+                                                 })
+            .getValue();
     }
 
     std::unique_ptr<GhaDescriptorSetLayout> createUiDescriptorSetLayout(GhaFactory &factory) {
@@ -152,12 +155,13 @@ namespace clove {
             .stage     = GhaShader::Stage::Pixel,
         };
 
-        return *factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
-            .bindings = {
-                textureBinding,
-                samplerBinding,
-            },
-        });
+        return factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
+                                                     .bindings = {
+                                                         textureBinding,
+                                                         samplerBinding,
+                                                     },
+                                                 })
+            .getValue();
     }
 
     std::unique_ptr<GhaDescriptorSetLayout> createSkinningDescriptorSetLayout(GhaFactory &factory) {
@@ -182,13 +186,14 @@ namespace clove {
             .stage     = GhaShader::Stage::Compute,
         };
 
-        return *factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
-            .bindings = {
-                skeletonBinding,
-                bindPoseBinding,
-                skinedPoseBinding,
-            },
-        });
+        return factory.createDescriptorSetLayout(GhaDescriptorSetLayout::Descriptor{
+                                                     .bindings = {
+                                                         skeletonBinding,
+                                                         bindPoseBinding,
+                                                         skinedPoseBinding,
+                                                     },
+                                                 })
+            .getValue();
     }
 
     std::unordered_map<DescriptorType, uint32_t> countDescriptorBindingTypes(GhaDescriptorSetLayout const &descriptorSetLayout) {
@@ -236,20 +241,21 @@ namespace clove {
         vec3i constexpr imageOffset{ 0, 0, 0 };
         vec3ui const imageExtent{ imageDescriptor.dimensions.x, imageDescriptor.dimensions.y, 1 };
 
-        auto transferQueue{ *factory.createTransferQueue({ QueueFlags::Transient }) };
-        auto graphicsQueue{ *factory.createGraphicsQueue({ QueueFlags::Transient }) };
+        auto transferQueue{ factory.createTransferQueue({ QueueFlags::Transient }).getValue() };
+        auto graphicsQueue{ factory.createGraphicsQueue({ QueueFlags::Transient }).getValue() };
 
         auto transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
         auto graphicsCommandBuffer{ graphicsQueue->allocateCommandBuffer() };
 
-        auto image{ *factory.createImage(imageDescriptor) };
+        auto image{ factory.createImage(imageDescriptor).getValue() };
 
-        auto transferBuffer = *factory.createBuffer(GhaBuffer::Descriptor{
-            .size        = dataSize,
-            .usageFlags  = GhaBuffer::UsageMode::TransferSource,
-            .sharingMode = SharingMode::Exclusive,
-            .memoryType  = MemoryType::SystemMemory,
-        });
+        auto transferBuffer{ factory.createBuffer(GhaBuffer::Descriptor{
+                                                      .size        = dataSize,
+                                                      .usageFlags  = GhaBuffer::UsageMode::TransferSource,
+                                                      .sharingMode = SharingMode::Exclusive,
+                                                      .memoryType  = MemoryType::SystemMemory,
+                                                  })
+                                 .getValue() };
         transferBuffer->write(data, bufferOffset, dataSize);
 
         //Change the layout of the image, write the buffer into it and then release the queue ownership
@@ -264,8 +270,8 @@ namespace clove {
         graphicsCommandBuffer->imageMemoryBarrier(*image, graphicsQueueAcquireInfo, PipelineStage::Transfer, PipelineStage::PixelShader);
         graphicsCommandBuffer->endRecording();
 
-        auto transferQueueFinishedFence{ *factory.createFence({ false }) };
-        auto graphicsQueueFinishedFence{ *factory.createFence({ false }) };
+        auto transferQueueFinishedFence{ factory.createFence({ false }).getValue() };
+        auto graphicsQueueFinishedFence{ factory.createFence({ false }).getValue() };
 
         transferQueue->submit({ TransferSubmitInfo{ .commandBuffers = { transferCommandBuffer.get() } } }, transferQueueFinishedFence.get());
         graphicsQueue->submit({ GraphicsSubmitInfo{ .commandBuffers = { graphicsCommandBuffer.get() } } }, graphicsQueueFinishedFence.get());

--- a/clove/source/Rendering/SwapchainRenderTarget.cpp
+++ b/clove/source/Rendering/SwapchainRenderTarget.cpp
@@ -19,10 +19,10 @@ namespace clove {
         surfaceSize         = swapchainSurface.getSize();
         surfaceResizeHandle = swapchainSurface.onSurfaceResize().bind(&SwapchainRenderTarget::onSurfaceSizeChanged, this);
 
-        presentQueue = *graphicsFactory->createPresentQueue();
+        presentQueue = graphicsFactory->createPresentQueue().getValue();
 
         //We won't be allocating any buffers from this queue, only using it to submit
-        graphicsQueue = *graphicsFactory->createGraphicsQueue(CommandQueueDescriptor{ .flags = QueueFlags::None });
+        graphicsQueue = graphicsFactory->createGraphicsQueue(CommandQueueDescriptor{ .flags = QueueFlags::None }).getValue();
 
         createSwapchain();
     }
@@ -44,10 +44,10 @@ namespace clove {
         }
 
         if(std::size(imageAvailableSemaphores) <= frameId) {
-            imageAvailableSemaphores.emplace_back(*graphicsFactory->createSemaphore());
+            imageAvailableSemaphores.emplace_back(graphicsFactory->createSemaphore().getValue());
         }
         if(std::size(framesInFlight) <= frameId) {
-            framesInFlight.emplace_back(*graphicsFactory->createFence({ true }));
+            framesInFlight.emplace_back(graphicsFactory->createFence({ true }).getValue());
         }
 
         //Wait for the graphics queue to be finished with the frame we want to render
@@ -72,7 +72,7 @@ namespace clove {
 
     void SwapchainRenderTarget::submit(uint32_t imageIndex, size_t const frameId, GraphicsSubmitInfo submission) {
         if(std::size(renderFinishedSemaphores) <= frameId) {
-            renderFinishedSemaphores.emplace_back(*graphicsFactory->createSemaphore());
+            renderFinishedSemaphores.emplace_back(graphicsFactory->createSemaphore().getValue());
         }
 
         //Inject the sempahores we use to synchronise with the swapchain and present queue
@@ -121,7 +121,7 @@ namespace clove {
         graphicsDevice->waitForIdleDevice();
 
         swapchain.reset();
-        swapchain = *graphicsFactory->createSwapChain({ surfaceSize });
+        swapchain = graphicsFactory->createSwapChain({ surfaceSize }).getValue();
 
         imagesInFlight.resize(std::size(swapchain->getImageViews()));
 

--- a/clove/source/SoundFile.cpp
+++ b/clove/source/SoundFile.cpp
@@ -81,10 +81,11 @@ namespace clove {
     }
 
     std::unique_ptr<AhaBuffer> SoundFile::read(uint32_t const frames) {
-        auto audioBuffer  = *Application::get().getAudioDevice()->getAudioFactory()->createAudioBuffer(AhaBuffer::Descriptor{
-            .format     = getBufferFormat(getFormat(), getChannels()),
-            .sampleRate = getSampleRate(),
-        });
+        auto audioBuffer{ Application::get().getAudioDevice()->getAudioFactory()->createAudioBuffer(AhaBuffer::Descriptor{
+                                                                                                        .format     = getBufferFormat(getFormat(), getChannels()),
+                                                                                                        .sampleRate = getSampleRate(),
+                                                                                                    })
+                              .getValue() };
         auto [data, size] = readRaw(frames);
 
         audioBuffer->write(data.get(), size);


### PR DESCRIPTION
## Summary
This is to enforce better readability and make the type itself look less like a pointer.

Closes #391 

## Changes
- Removed the dereference operators from `Expected`