### PR TITLE
Transfer operations can now handle images arrays and cube maps

### DIFF
--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferCommandBuffer.hpp
@@ -28,10 +28,38 @@ namespace clove {
         virtual void beginRecording(CommandBufferUsage usageFlag) = 0;
         virtual void endRecording()                               = 0;
 
-        virtual void copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes)        = 0;
-        virtual void copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent) = 0;
+        /**
+         * @brief Copy the contents from one buffer to another.
+         * @param source 
+         * @param sourceOffset 
+         * @param destination 
+         * @param destinationOffset 
+         * @param sizeBytes 
+         */
+        virtual void copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes) = 0;
+        /**
+         * @brief Copy the content from a buffer to an image.
+         * @param source 
+         * @param sourceOffset 
+         * @param destination 
+         * @param destinationOffset 
+         * @param destinationExtent 
+         * @param destinationBaseLayer If the image is an array and/or a cube map, which index to start the copy from. Otherwise will be 0.
+         * @param destinationLayerCount If the image is an array and/or a cube map, how many layers to copy. Otherwise will be 1.
+         */
+        virtual void copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent, uint32_t const destinationBaseLayer, uint32_t const destinationLayerCount) = 0;
 
-        virtual void copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, GhaBuffer &destination, size_t const destinationOffset) = 0;
+        /**
+         * @brief Copy the contents of an image to a buffer.
+         * @param source 
+         * @param sourceOffset 
+         * @param sourceExtent 
+         * @param sourceBaseLayer If the image is an array and/or a cube map, which index to start the copy from. Otherwise will be 0.
+         * @param sourceLayerCount If the image is an array and/or a cube map, how many layers to copy. Otherwise will be 1.
+         * @param destination 
+         * @param destinationOffset 
+         */
+        virtual void copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, uint32_t const sourceBaseLayer, uint32_t const sourceLayerCount, GhaBuffer &destination, size_t const destinationOffset) = 0;
 
         /**
          * @brief Creates a memory barrier for a buffer. Controlling execution order of commands on the buffer.

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferCommandBuffer.hpp
@@ -28,11 +28,11 @@ namespace clove {
 		void endRecording() override;
 
 		void copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes) override;
-		void copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent) override;
+        void copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent, uint32_t const destinationBaseLayer, uint32_t const destinationLayerCount) override;
 
-		void copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, GhaBuffer &destination, size_t const destinationOffset) override;
+        void copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, uint32_t const sourceBaseLayer, uint32_t const sourceLayerCount, GhaBuffer &destination, size_t const destinationOffset) override;
 
-		void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
+        void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 		void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 		
 		inline std::vector<std::function<void(id<MTLBlitCommandEncoder>)>> const &getCommands() const;

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp
@@ -30,9 +30,9 @@ namespace clove {
         void endRecording() override;
 
         void copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes) override;
-        void copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent) override;
+        void copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent, uint32_t const destinationBaseLayer, uint32_t const destinationLayerCount) override;
 
-        void copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, GhaBuffer &destination, size_t const destinationOffset) override;
+        void copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, uint32_t const sourceBaseLayer, uint32_t const sourceLayerCount, GhaBuffer &destination, size_t const destinationOffset) override;
 
         void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
         void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
@@ -49,16 +49,16 @@ namespace clove {
         vkCmdCopyBuffer(commandBuffer, polyCast<VulkanBuffer>(&source)->getBuffer(), polyCast<VulkanBuffer>(&destination)->getBuffer(), 1, &copyRegion);
     }
 
-    void VulkanTransferCommandBuffer::copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent) {
-        VkBufferImageCopy copyRegion{
+    void VulkanTransferCommandBuffer::copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent, uint32_t const destinationBaseLayer, uint32_t const destinationLayerCount) {
+        VkBufferImageCopy const copyRegion{
             .bufferOffset      = sourceOffset,
             .bufferRowLength   = 0,//Tightly packed
             .bufferImageHeight = 0,//Tightly packed
             .imageSubresource  = {
                 .aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,//TODO: Handle other aspect masks
                 .mipLevel       = 0,
-                .baseArrayLayer = 0,
-                .layerCount     = 1,
+                .baseArrayLayer = destinationBaseLayer,
+                .layerCount     = destinationLayerCount,
             },
             .imageOffset = { destinationOffset.x, destinationOffset.y, destinationOffset.z },
             .imageExtent = { destinationExtent.x, destinationExtent.y, destinationExtent.z },
@@ -67,16 +67,16 @@ namespace clove {
         vkCmdCopyBufferToImage(commandBuffer, polyCast<VulkanBuffer>(&source)->getBuffer(), polyCast<VulkanImage>(&destination)->getImage(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyRegion);
     }
 
-    void VulkanTransferCommandBuffer::copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, GhaBuffer &destination, size_t const destinationOffset) {
-        VkBufferImageCopy copyRegion{
+    void VulkanTransferCommandBuffer::copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, uint32_t const sourceBaseLayer, uint32_t const sourceLayerCount, GhaBuffer &destination, size_t const destinationOffset) {
+        VkBufferImageCopy const copyRegion{
             .bufferOffset      = destinationOffset,
             .bufferRowLength   = 0,//Tightly packed
             .bufferImageHeight = 0,//Tightly packed
             .imageSubresource  = {
                 .aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,//TODO: Handle other aspect masks
                 .mipLevel       = 0,
-                .baseArrayLayer = 0,
-                .layerCount     = 1,
+                .baseArrayLayer = sourceBaseLayer,
+                .layerCount     = sourceLayerCount,
             },
             .imageOffset = { sourceOffset.x, sourceOffset.y, sourceOffset.z },
             .imageExtent = { sourceExtent.x, sourceExtent.y, sourceExtent.z },

--- a/clove/source/Rendering/GraphicsImageRenderTarget.cpp
+++ b/clove/source/Rendering/GraphicsImageRenderTarget.cpp
@@ -118,7 +118,7 @@ namespace clove {
 
         transferCommandBuffer->beginRecording(CommandBufferUsage::Default);
         transferCommandBuffer->imageMemoryBarrier(*renderTargetImage, layoutTransferInfo, PipelineStage::Top, PipelineStage::Transfer);
-        transferCommandBuffer->copyImageToBuffer(*renderTargetImage, { 0, 0, 0 }, { imageDescriptor.dimensions, 1 }, *renderTargetBuffer, 0);
+        transferCommandBuffer->copyImageToBuffer(*renderTargetImage, { 0, 0, 0 }, { imageDescriptor.dimensions, 1 }, 0, 1, *renderTargetBuffer, 0);
         transferCommandBuffer->endRecording();
 
         onPropertiesChangedEnd.broadcast();

--- a/clove/source/Rendering/RenderingHelpers.cpp
+++ b/clove/source/Rendering/RenderingHelpers.cpp
@@ -261,7 +261,7 @@ namespace clove {
         //Change the layout of the image, write the buffer into it and then release the queue ownership
         transferCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
         transferCommandBuffer->imageMemoryBarrier(*image, layoutTransferInfo, PipelineStage::Top, PipelineStage::Transfer);
-        transferCommandBuffer->copyBufferToImage(*transferBuffer, bufferOffset, *image, imageOffset, imageExtent);
+        transferCommandBuffer->copyBufferToImage(*transferBuffer, bufferOffset, *image, imageOffset, imageExtent, 0, imageDescriptor.arrayCount);
         transferCommandBuffer->imageMemoryBarrier(*image, transferQueueReleaseInfo, PipelineStage::Transfer, PipelineStage::Transfer);
         transferCommandBuffer->endRecording();
 


### PR DESCRIPTION
## Summary
Closes #333 

## Changes
- `GhaTransferCommandBuffer` can now handle image arrays and cube maps.