### PR TITLE
`Animator` now uses a pointer to a const `AnimationClip`

### DIFF
--- a/clove/include/Clove/Rendering/Animator.hpp
+++ b/clove/include/Clove/Rendering/Animator.hpp
@@ -20,7 +20,7 @@ namespace clove {
         //VARIABLES
     private:
         float currentTime{ 0.0f };
-        AnimationClip *currentClip{ nullptr };
+        AnimationClip const *currentClip{ nullptr };
 
         //FUNCTIONS
     public:
@@ -45,7 +45,7 @@ namespace clove {
          * @brief Sets the current clip the Animator will use
          * @param clip Pointer to the new clip
          */
-        void setCurrentClip(AnimationClip *clip);
+        void setCurrentClip(AnimationClip const *clip);
 
     private:
         std::pair<AnimationPose const &, AnimationPose const &> getPrevNextPose(float animationTime);

--- a/clove/source/Rendering/Animator.cpp
+++ b/clove/source/Rendering/Animator.cpp
@@ -100,7 +100,7 @@ namespace clove {
         return skinningMatrix;
     }
 
-    void Animator::setCurrentClip(AnimationClip *clip) {
+    void Animator::setCurrentClip(AnimationClip const *clip) {
         currentClip = clip;
     }
 


### PR DESCRIPTION
## Summary
This basically enables better compatibility with `AnimatedModel::getAnimationClips`

## Changes
- `Animator` now uses a pointer to a const `AnimationClip`