### PR TITLE
Fixed GPU memory issue on smaller devices

### DIFF
--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/MemoryAllocator.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/MemoryAllocator.hpp
@@ -60,7 +60,7 @@ namespace clove {
             //FUNCTIONS
         public:
             Block() = delete;
-            Block(VkDevice device, VkDeviceSize size, uint32_t memoryTypeIndex);
+            Block(VkDevice device, VkDeviceMemory memory, VkDeviceSize size, uint32_t memoryTypeIndex);
 
             Block(Block const &other) = delete;
             Block(Block &&other) noexcept;
@@ -80,7 +80,7 @@ namespace clove {
 
         //VARIABLES
     private:
-        static VkDeviceSize constexpr blockSize = 256 * 1024 * 1024;//256MB
+        static VkDeviceSize constexpr blockSize{ 256 * 1024 * 1024 };//256MB
 
         DevicePointer device;
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanBuffer.hpp
@@ -26,7 +26,7 @@ namespace clove {
         //FUNCTIONS
     public:
         VulkanBuffer() = delete;
-        VulkanBuffer(DevicePointer device, VkBuffer buffer, Descriptor descriptor, std::shared_ptr<MemoryAllocator> memoryAllocator);
+        VulkanBuffer(DevicePointer device, VkBuffer buffer, Descriptor descriptor, MemoryAllocator::Chunk const *allocatedBlock, std::shared_ptr<MemoryAllocator> memoryAllocator);
 
         VulkanBuffer(VulkanBuffer const &other) = delete;
         VulkanBuffer(VulkanBuffer &&other) noexcept;

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanImage.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanImage.hpp
@@ -22,18 +22,18 @@ namespace clove {
         Descriptor descriptor{};
 
         std::shared_ptr<MemoryAllocator> memoryAllocator;
-        const MemoryAllocator::Chunk* allocatedBlock{ nullptr };
+        MemoryAllocator::Chunk const *allocatedBlock{ nullptr };
 
         //FUNCTIONS
     public:
         VulkanImage() = delete;
-        VulkanImage(DevicePointer device, VkImage image, Descriptor descriptor, std::shared_ptr<MemoryAllocator> memoryAllocator);
+        VulkanImage(DevicePointer device, VkImage image, Descriptor descriptor, MemoryAllocator::Chunk const *allocatedBlock, std::shared_ptr<MemoryAllocator> memoryAllocator);
 
-        VulkanImage(VulkanImage const& other) = delete;
-        VulkanImage(VulkanImage&& other) noexcept;
+        VulkanImage(VulkanImage const &other) = delete;
+        VulkanImage(VulkanImage &&other) noexcept;
 
-        VulkanImage& operator=(VulkanImage const& other) = delete;
-        VulkanImage& operator=(VulkanImage&& other) noexcept;
+        VulkanImage &operator=(VulkanImage const &other) = delete;
+        VulkanImage &operator=(VulkanImage &&other) noexcept;
 
         ~VulkanImage();
 

--- a/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
+++ b/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
@@ -192,7 +192,9 @@ namespace clove {
             };
             vkGetPhysicalDeviceMemoryProperties2(device.getPhysical(), &properties);
 
-            CLOVE_LOG(CloveGhaVulkan, LogLevel::Debug, "Allocated block of {0} bytes. Current heap usage: {1} / {2}", size, memoryBudgetProperties.heapUsage[0], memoryBudgetProperties.heapBudget[0]);
+            uint32_t const heapIndex{ properties.memoryProperties.memoryTypes[memoryTypeIndex].heapIndex };
+
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Trace, "Allocated block of {0} bytes from heap {1}. Current heap usage: {2} / {3}", size, heapIndex, memoryBudgetProperties.heapUsage[heapIndex], memoryBudgetProperties.heapBudget[heapIndex]);
 #endif
 
             memoryBlocks.emplace_back(device.get(), memory, size, memoryTypeIndex);
@@ -210,18 +212,5 @@ namespace clove {
                 break;
             }
         }
-
-#if CLOVE_GHA_VALIDATION
-        VkPhysicalDeviceMemoryBudgetPropertiesEXT memoryBudgetProperties{
-            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT,
-        };
-        VkPhysicalDeviceMemoryProperties2 properties{
-            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
-            .pNext = &memoryBudgetProperties,
-        };
-        vkGetPhysicalDeviceMemoryProperties2(device.getPhysical(), &properties);
-
-        CLOVE_LOG(CloveGhaVulkan, LogLevel::Debug, "Device memory freed. Current heap usage: {0} / {1}", memoryBudgetProperties.heapUsage[0], memoryBudgetProperties.heapBudget[0]);
-#endif
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
+++ b/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
@@ -1,7 +1,6 @@
 #include "Clove/Graphics/Vulkan/MemoryAllocator.hpp"
 
-#include <Clove/Definitions.hpp>
-#include <Clove/Log/Log.hpp>
+#include "Clove/Graphics/Vulkan/VulkanLog.hpp"
 
 namespace clove {
     namespace {
@@ -20,27 +19,20 @@ namespace clove {
         }
     }
 
-    MemoryAllocator::Block::Block(VkDevice device, VkDeviceSize size, uint32_t memoryTypeIndex)
-        : device(device)
-        , size(size)
-        , memoryTypeIndex(memoryTypeIndex) {
-        VkMemoryAllocateInfo info{};
-        info.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        info.pNext           = nullptr;
-        info.allocationSize  = size;
-        info.memoryTypeIndex = memoryTypeIndex;
-
-        vkAllocateMemory(device, &info, nullptr, &memory);
-
+    MemoryAllocator::Block::Block(VkDevice device, VkDeviceMemory memory, VkDeviceSize size, uint32_t memoryTypeIndex)
+        : device{ device }
+        , memory{ memory }
+        , size{ size }
+        , memoryTypeIndex{ memoryTypeIndex } {
         chunks.emplace_back(0, size, memory);
     }
 
     MemoryAllocator::Block::Block(Block &&other) noexcept
-        : device(other.device)
-        , memory(other.memory)
-        , size(other.size)
-        , memoryTypeIndex(other.memoryTypeIndex)
-        , chunks(std::move(other.chunks)) {
+        : device{ other.device }
+        , memory{ other.memory }
+        , size{ other.size }
+        , memoryTypeIndex{ other.memoryTypeIndex }
+        , chunks{ std::move(other.chunks) } {
         other.memory = VK_NULL_HANDLE;//Make sure the moved block no longer points to our memory
     }
 
@@ -133,12 +125,12 @@ namespace clove {
     }
 
     MemoryAllocator::MemoryAllocator(DevicePointer device)
-        : device(std::move(device)) {
+        : device{ std::move(device) } {
     }
 
     MemoryAllocator::MemoryAllocator(MemoryAllocator &&other) noexcept = default;
 
-    MemoryAllocator &MemoryAllocator::operator=(MemoryAllocator &&other)  noexcept = default;
+    MemoryAllocator &MemoryAllocator::operator=(MemoryAllocator &&other) noexcept = default;
 
     MemoryAllocator::~MemoryAllocator() = default;
 
@@ -159,8 +151,40 @@ namespace clove {
         if(freeChunk == nullptr) {
             //Make sure if allocate a new block that's big enough
             VkDeviceSize const size{ std::max(memoryRequirements.size, blockSize) };
-            memoryBlocks.emplace_back(device.get(), size, memoryTypeIndex);
+
+            VkMemoryAllocateInfo const info{
+                .sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+                .pNext           = nullptr,
+                .allocationSize  = size,
+                .memoryTypeIndex = memoryTypeIndex,
+            };
+
+            VkDeviceMemory memory{ VK_NULL_HANDLE };
+            if(VkResult const result{ vkAllocateMemory(device.get(), &info, nullptr, &memory) }; result != VK_SUCCESS) {
+                switch(result) {
+                    case VK_ERROR_OUT_OF_HOST_MEMORY:
+                        CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Could not allocate memory. Out of host memory.");
+                        break;
+                    case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+                        CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Could not allocate memory. Out of device memory.");
+                        break;
+                    case VK_ERROR_INVALID_EXTERNAL_HANDLE:
+                        CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Could not allocate memory. Invalid External handle.");
+                        break;
+                    case VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR:
+                        CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Could not allocate memory. Invalid opaque capture address.");
+                        break;
+                    default:
+                        CLOVE_LOG(CloveGhaVulkan, LogLevel::Error, "Could not allocate memory. Reason Unknown.");
+                        break;
+                }
+
+                return nullptr;
+            }
+
+            memoryBlocks.emplace_back(device.get(), memory, size, memoryTypeIndex);
             freeChunk = memoryBlocks.back().allocate(memoryRequirements.size, memoryRequirements.alignment);
+
             CLOVE_ASSERT_MSG(freeChunk != nullptr, "{0}: Newly allocated Block does not have enough room", CLOVE_FUNCTION_NAME_PRETTY);
         }
 

--- a/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
+++ b/clove/components/core/graphics/source/Vulkan/MemoryAllocator.cpp
@@ -182,6 +182,19 @@ namespace clove {
                 return nullptr;
             }
 
+#if CLOVE_GHA_VALIDATION
+            VkPhysicalDeviceMemoryBudgetPropertiesEXT memoryBudgetProperties{
+                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT,
+            };
+            VkPhysicalDeviceMemoryProperties2 properties{
+                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
+                .pNext = &memoryBudgetProperties,
+            };
+            vkGetPhysicalDeviceMemoryProperties2(device.getPhysical(), &properties);
+
+            CLOVE_LOG(CloveGhaVulkan, LogLevel::Debug, "Allocated block of {0} bytes. Current heap usage: {1} / {2}", size, memoryBudgetProperties.heapUsage[0], memoryBudgetProperties.heapBudget[0]);
+#endif
+
             memoryBlocks.emplace_back(device.get(), memory, size, memoryTypeIndex);
             freeChunk = memoryBlocks.back().allocate(memoryRequirements.size, memoryRequirements.alignment);
 
@@ -197,5 +210,18 @@ namespace clove {
                 break;
             }
         }
+
+#if CLOVE_GHA_VALIDATION
+        VkPhysicalDeviceMemoryBudgetPropertiesEXT memoryBudgetProperties{
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT,
+        };
+        VkPhysicalDeviceMemoryProperties2 properties{
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
+            .pNext = &memoryBudgetProperties,
+        };
+        vkGetPhysicalDeviceMemoryProperties2(device.getPhysical(), &properties);
+
+        CLOVE_LOG(CloveGhaVulkan, LogLevel::Debug, "Device memory freed. Current heap usage: {0} / {1}", memoryBudgetProperties.heapUsage[0], memoryBudgetProperties.heapBudget[0]);
+#endif
     }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanBuffer.cpp
@@ -6,30 +6,12 @@
 #include <Clove/Log/Log.hpp>
 
 namespace clove {
-    namespace {
-        VkMemoryPropertyFlags getMemoryPropertyFlags(MemoryType garlicProperties) {
-            switch(garlicProperties) {
-                case MemoryType::VideoMemory:
-                    return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-                case MemoryType::SystemMemory:
-                    return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;//Including HOST_COHERENT here as this makes mapping memory more simple
-                default:
-                    break;
-            }
-        }
-    }
-
-    VulkanBuffer::VulkanBuffer(DevicePointer device, VkBuffer buffer, Descriptor descriptor, std::shared_ptr<MemoryAllocator> memoryAllocator)
+    VulkanBuffer::VulkanBuffer(DevicePointer device, VkBuffer buffer, Descriptor descriptor, MemoryAllocator::Chunk const *allocatedBlock, std::shared_ptr<MemoryAllocator> memoryAllocator)
         : device{ std::move(device) }
         , buffer{ buffer }
         , descriptor{ descriptor }
+        , allocatedBlock{ allocatedBlock }
         , memoryAllocator{ std::move(memoryAllocator) } {
-        VkMemoryRequirements memoryRequirements{};
-        vkGetBufferMemoryRequirements(this->device.get(), buffer, &memoryRequirements);
-
-        allocatedBlock = this->memoryAllocator->allocate(memoryRequirements, getMemoryPropertyFlags(this->descriptor.memoryType));
-
-        vkBindBufferMemory(this->device.get(), buffer, allocatedBlock->memory, allocatedBlock->offset);
     }
 
     VulkanBuffer::VulkanBuffer(VulkanBuffer &&other) noexcept = default;

--- a/clove/components/core/graphics/source/Vulkan/VulkanImage.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanImage.cpp
@@ -34,17 +34,12 @@ namespace clove {
         }
     }
 
-    VulkanImage::VulkanImage(DevicePointer device, VkImage image, Descriptor descriptor, std::shared_ptr<MemoryAllocator> memoryAllocator)
+    VulkanImage::VulkanImage(DevicePointer device, VkImage image, Descriptor descriptor, MemoryAllocator::Chunk const *allocatedBlock, std::shared_ptr<MemoryAllocator> memoryAllocator)
         : device{ std::move(device) }
         , image{ image }
         , descriptor{ descriptor }
+        , allocatedBlock{ allocatedBlock }
         , memoryAllocator{ std::move(memoryAllocator) } {
-        VkMemoryRequirements memoryRequirements{};
-        vkGetImageMemoryRequirements(this->device.get(), image, &memoryRequirements);
-
-        allocatedBlock = this->memoryAllocator->allocate(memoryRequirements, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-        vkBindImageMemory(this->device.get(), image, allocatedBlock->memory, allocatedBlock->offset);
     }
 
     VulkanImage::VulkanImage(VulkanImage &&other) noexcept = default;

--- a/clove/source/Rendering/ForwardRenderer3D.cpp
+++ b/clove/source/Rendering/ForwardRenderer3D.cpp
@@ -508,6 +508,8 @@ namespace clove {
             graphicsQueue->freeCommandBuffer(imageData.cubeShadowMapCommandBuffer);
             computeQueue->freeCommandBuffer(imageData.skinningCommandBuffer);
         }
+
+        inFlightImageData.clear();
     }
 
     void ForwardRenderer3D::createRenderTargetResources() {


### PR DESCRIPTION
## Summary
`ForwardRenderer3D::cleanupRenderTargetResources` now also empties the `inFlightImageData` array. This means that the allocator will have as much space as possible free before we attempt to recreate the resources later on.

Closes #313 

## Changes
- Added memory logging to vulkan when `CLOVE_GHA_VALIDATION` is enabled.
- Fixed an issue where not enough memory could be free before re-allocating frame resources.
