### PR TITLE
Using `stead_clock` instead of `system_clock` for frame delta time

### DIFF
--- a/clove/include/Clove/Application.hpp
+++ b/clove/include/Clove/Application.hpp
@@ -63,7 +63,7 @@ namespace clove {
         std::unordered_map<std::type_index, std::pair<SubSystemGroup, size_t>> subSystemToIndex; /**< Contains the index for each subsystem in the subSystems array. */
         std::map<SubSystemGroup, std::vector<std::unique_ptr<SubSystem>>> subSystems;
 
-        std::chrono::system_clock::time_point prevFrameTime;
+        std::chrono::steady_clock::time_point prevFrameTime;
 
         //FUNCTIONS
     public:

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -71,7 +71,7 @@ namespace clove {
             return;
         }
 
-        auto const currFrameTime{ std::chrono::system_clock::now() };
+        auto const currFrameTime{ std::chrono::steady_clock::now() };
         std::chrono::duration<float> const deltaSeonds{ currFrameTime - prevFrameTime };
         prevFrameTime = currFrameTime;
 
@@ -125,7 +125,7 @@ namespace clove {
         CLOVE_ASSERT_MSG(instance == nullptr, "Only one Application can be active");
         instance = this;
 
-        prevFrameTime = std::chrono::system_clock::now();
+        prevFrameTime = std::chrono::steady_clock::now();
 
         //Systems
         renderer = std::make_unique<ForwardRenderer3D>(this->graphicsDevice.get(), std::move(renderTarget));


### PR DESCRIPTION
## Changes
- Using `stead_clock` instead of `system_clock` for frame delta time
