### PR TITLE
Refactored `SubSystem`s to return their own group

### DIFF
--- a/bulb/components/membrane/include/Membrane/EditorSubSystem.hpp
+++ b/bulb/components/membrane/include/Membrane/EditorSubSystem.hpp
@@ -37,6 +37,8 @@ namespace membrane {
         EditorSubSystem();
         ~EditorSubSystem();
 
+        Group getGroup() const override;
+
         void onAttach() override;
         clove::InputResponse onInputEvent(clove::InputEvent const &inputEvent) override;
         void onUpdate(clove::DeltaTime const deltaTime) override;

--- a/bulb/components/membrane/include/Membrane/RuntimeSubSystem.hpp
+++ b/bulb/components/membrane/include/Membrane/RuntimeSubSystem.hpp
@@ -22,6 +22,8 @@ namespace membrane {
     public:
         RuntimeSubSystem();
 
+        Group getGroup() const override;
+
         void onAttach() override;
         clove::InputResponse onInputEvent(clove::InputEvent const &inputEvent) override { return clove::InputResponse::Ignored; }
         void onUpdate(clove::DeltaTime const deltaTime) override;

--- a/bulb/components/membrane/source/EditorSubSystem.cpp
+++ b/bulb/components/membrane/source/EditorSubSystem.cpp
@@ -152,6 +152,10 @@ namespace membrane {
         proxy->reset();
     }
 
+    clove::SubSystem::Group EditorSubSystem::getGroup() const {
+        return Group::Core;
+    }
+
     void EditorSubSystem::onAttach() {
         auto &app{ clove::Application::get() };
 

--- a/bulb/components/membrane/source/RuntimeSubSystem.cpp
+++ b/bulb/components/membrane/source/RuntimeSubSystem.cpp
@@ -16,11 +16,15 @@ namespace membrane {
         , currentScene{ clove::Application::get().getEntityManager() } {
     }
 
+    clove::SubSystem::Group RuntimeSubSystem::getGroup() const {
+        return Group::Core;
+    }
+
     void RuntimeSubSystem::onAttach() {
         auto &app{ clove::Application::get() };
 
         //push the physics sub system from the application
-        app.pushSubSystem<clove::PhysicsSubSystem>(clove::Application::SubSystemGroup::Initialisation, app.getEntityManager());
+        app.pushSubSystem<clove::PhysicsSubSystem>(app.getEntityManager());
 
         currentScene.load(app.getFileSystem()->resolve("./scene.clvscene"));
     }

--- a/clove/include/Clove/Application.hpp
+++ b/clove/include/Clove/Application.hpp
@@ -35,13 +35,6 @@ namespace clove {
             Stopped
         };
 
-        enum class SubSystemGroup {
-            Initialisation, /**< For layers that need to perform logic before anything else. */
-            Core,           /**< The default group. For layers that contain core / general functionality. */
-            Interface,      /**< For layers that contain interface logic. Usually UI */
-            Render,         /**< For layers that need be run very last. Usually for some form of rendering logic. */
-        };
-
         //VARIABLES
     private:
         static Application *instance;
@@ -60,8 +53,8 @@ namespace clove {
         VirtualFileSystem fileSystem{};
         AssetManager assetManager;
 
-        std::unordered_map<std::type_index, std::pair<SubSystemGroup, size_t>> subSystemToIndex; /**< Contains the index for each subsystem in the subSystems array. */
-        std::map<SubSystemGroup, std::vector<std::unique_ptr<SubSystem>>> subSystems;
+        std::unordered_map<std::type_index, std::pair<SubSystem::Group, size_t>> subSystemToIndex; /**< Contains the index for each subsystem in the subSystems array. */
+        std::map<SubSystem::Group, std::vector<std::unique_ptr<SubSystem>>> subSystems;
 
         std::chrono::steady_clock::time_point prevFrameTime;
 
@@ -107,8 +100,6 @@ namespace clove {
 
         template<typename SubSystemType, typename... Args>
         void pushSubSystem(Args &&...args);
-        template<typename SubSystemType, typename... Args>
-        void pushSubSystem(SubSystemGroup group, Args &&...args);
 
         template<typename SubSystemType>
         SubSystemType &getSubSystem();

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -5,11 +5,6 @@ CLOVE_DECLARE_LOG_CATEGORY(CloveApplication)
 namespace clove {
     template<typename SubSystemType, typename... Args>
     void Application::pushSubSystem(Args &&...args) {
-        pushSubSystem<SubSystemType>(SubSystemGroup::Core, std::forward<Args>(args)...);
-    }
-
-    template<typename SubSystemType, typename... Args>
-    void Application::pushSubSystem(SubSystemGroup group, Args &&...args) {
         static_assert(std::is_base_of_v<SubSystem, SubSystemType>, "SubSystem provided is not derived from SubSystem.");
 
         std::type_index const subSystemIndex{ typeid(SubSystemType) };
@@ -18,6 +13,8 @@ namespace clove {
         auto subSystem{ std::make_unique<SubSystemType>(std::forward<Args>(args)...) };
 
         CLOVE_LOG(CloveApplication, LogLevel::Trace, "Attached sub system: {0}", subSystem->getName());
+
+        SubSystem::Group const group{ subSystem->getGroup() };
 
         subSystem->onAttach();
         subSystems[group].push_back(std::move(subSystem));

--- a/clove/include/Clove/SubSystem.hpp
+++ b/clove/include/Clove/SubSystem.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Clove/InputResponse.hpp"
 #include "Clove/InputEvent.hpp"
+#include "Clove/InputResponse.hpp"
 
 #include <Clove/DeltaTime.hpp>
 
@@ -10,6 +10,15 @@ namespace clove {
      * @brief A SubSystem represents a slice of functionality that can be injected into Clove.
      */
     class SubSystem {
+        //TYPES
+    public:
+        enum class Group {
+            Initialisation, /**< For layers that need to perform logic before anything else. */
+            Core,           /**< The default group. For layers that contain core / general functionality. */
+            Interface,      /**< For layers that contain interface logic. Usually UI */
+            Render,         /**< For layers that need be run very last. Usually for some form of rendering logic. */
+        };
+
         //VARIABLES
     protected:
         std::string debugName;
@@ -19,7 +28,9 @@ namespace clove {
         inline SubSystem(std::string name);
         virtual ~SubSystem() = default;
 
-        virtual void onAttach() = 0;
+        virtual Group getGroup() const = 0;
+
+        virtual void onAttach()                                          = 0;
         virtual InputResponse onInputEvent(InputEvent const &inputEvent) = 0;
         virtual void onUpdate(DeltaTime const deltaTime)                 = 0;
         virtual void onDetach()                                          = 0;

--- a/clove/include/Clove/SubSystems/AudioSubSystem.hpp
+++ b/clove/include/Clove/SubSystems/AudioSubSystem.hpp
@@ -28,6 +28,8 @@ namespace clove {
 
         ~AudioSubSystem();
 
+        Group getGroup() const override;
+
         void onAttach() override{};
         InputResponse onInputEvent(InputEvent const &inputEvent) override{ return InputResponse::Ignored; }
         void onUpdate(DeltaTime const deltaTime) override;

--- a/clove/include/Clove/SubSystems/PhysicsSubSystem.hpp
+++ b/clove/include/Clove/SubSystems/PhysicsSubSystem.hpp
@@ -86,6 +86,8 @@ namespace clove {
 
         ~PhysicsSubSystem();
 
+        Group getGroup() const override;
+
         void onAttach() override{};
         InputResponse onInputEvent(InputEvent const &inputEvent) override{ return InputResponse::Ignored; }
         void onUpdate(DeltaTime const deltaTime) override;

--- a/clove/include/Clove/SubSystems/RenderSubSystem.hpp
+++ b/clove/include/Clove/SubSystems/RenderSubSystem.hpp
@@ -29,6 +29,8 @@ namespace clove {
 
         ~RenderSubSystem();
 
+        Group getGroup() const override;
+
         void onAttach() override{};
         InputResponse onInputEvent(InputEvent const &inputEvent) override{ return InputResponse::Ignored; }
         void onUpdate(DeltaTime const deltaTime) override;

--- a/clove/include/Clove/SubSystems/TransformSubSystem.hpp
+++ b/clove/include/Clove/SubSystems/TransformSubSystem.hpp
@@ -28,6 +28,8 @@ namespace clove {
 
         ~TransformSubSystem();
 
+        Group getGroup() const override;
+
         void onAttach() override{};
         InputResponse onInputEvent(InputEvent const &inputEvent) override{ return InputResponse::Ignored; }
         void onUpdate(DeltaTime const deltaTime) override;

--- a/clove/source/SubSystems/AudioSubSystem.cpp
+++ b/clove/source/SubSystems/AudioSubSystem.cpp
@@ -22,6 +22,10 @@ namespace clove {
 
     AudioSubSystem::~AudioSubSystem() = default;
 
+    SubSystem::Group AudioSubSystem::getGroup() const {
+        return Group::Render;
+    }
+
     void AudioSubSystem::onUpdate(DeltaTime const deltaTime) {
         CLOVE_PROFILE_FUNCTION();
 

--- a/clove/source/SubSystems/PhysicsSubSystem.cpp
+++ b/clove/source/SubSystems/PhysicsSubSystem.cpp
@@ -90,6 +90,10 @@ namespace clove {
 
     PhysicsSubSystem::~PhysicsSubSystem() = default;
 
+    SubSystem::Group PhysicsSubSystem::getGroup() const {
+        return Group::Initialisation;
+    }
+
     void PhysicsSubSystem::onUpdate(DeltaTime const deltaTime) {
         CLOVE_PROFILE_FUNCTION();
 

--- a/clove/source/SubSystems/RenderSubSystem.cpp
+++ b/clove/source/SubSystems/RenderSubSystem.cpp
@@ -27,6 +27,10 @@ namespace clove {
 
     RenderSubSystem::~RenderSubSystem() = default;
 
+    SubSystem::Group RenderSubSystem::getGroup() const {
+        return Group::Render;
+    }
+
     void RenderSubSystem::onUpdate(DeltaTime const deltaTime) {
         CLOVE_PROFILE_FUNCTION();
 

--- a/clove/source/SubSystems/TransformSubSystem.cpp
+++ b/clove/source/SubSystems/TransformSubSystem.cpp
@@ -37,6 +37,10 @@ namespace clove {
 
     TransformSubSystem::~TransformSubSystem() = default;
 
+    SubSystem::Group TransformSubSystem::getGroup() const {
+        return Group::Initialisation;
+    }
+
     void TransformSubSystem::onUpdate(DeltaTime const deltaTime) {
         CLOVE_PROFILE_FUNCTION();
 


### PR DESCRIPTION
## Summary
This is to make sure that the sub systems are placed in the group they are designed to be in.

## Changes
- Refactored `SubSystem`s to return their own group.