### PR TITLE
Revert "Updated `gtest` package name to `GTest`"

### DIFF
--- a/clove/components/systems/ecs/tests/CMakeLists.txt
+++ b/clove/components/systems/ecs/tests/CMakeLists.txt
@@ -1,14 +1,14 @@
 #Entity
 add_executable(ECSEntityTest EntityTests.cpp)
-target_link_libraries(ECSEntityTest PRIVATE CONAN_PKG::GTest CloveECS)
+target_link_libraries(ECSEntityTest PRIVATE CONAN_PKG::gtest CloveECS)
 add_test(NAME ECSEntityTest COMMAND ECSEntityTest)
 
 #Component
 add_executable(ECSComponentTest ComponentTests.cpp)
-target_link_libraries(ECSComponentTest PRIVATE CONAN_PKG::GTest CloveECS)
+target_link_libraries(ECSComponentTest PRIVATE CONAN_PKG::gtest CloveECS)
 add_test(NAME ECSComponentTest COMMAND ECSComponentTest)
 
 #System
 add_executable(ECSSystemTest SystemTests.cpp)
-target_link_libraries(ECSSystemTest PRIVATE CONAN_PKG::GTest CloveECS)
+target_link_libraries(ECSSystemTest PRIVATE CONAN_PKG::gtest CloveECS)
 add_test(NAME ECSSystemTest COMMAND ECSSystemTest)

--- a/clove/components/systems/serialisation/tests/CMakeLists.txt
+++ b/clove/components/systems/serialisation/tests/CMakeLists.txt
@@ -1,14 +1,14 @@
 #Node
 add_executable(NodeTest NodeTests.cpp)
-target_link_libraries(NodeTest PRIVATE CONAN_PKG::GTest CloveSerialisation)
+target_link_libraries(NodeTest PRIVATE CONAN_PKG::gtest CloveSerialisation)
 add_test(NAME NodeTest COMMAND NodeTest)
 
 #Serialisation
 add_executable(YamlSerialisationTest YamlSerialisationTests.cpp)
-target_link_libraries(YamlSerialisationTest PRIVATE CONAN_PKG::GTest CloveSerialisation)
+target_link_libraries(YamlSerialisationTest PRIVATE CONAN_PKG::gtest CloveSerialisation)
 add_test(NAME YamlSerialisationTest COMMAND YamlSerialisationTest)
 
 #Deerialisation
 add_executable(YamlDeserialisationTest YamlDeserialisationTests.cpp)
-target_link_libraries(YamlDeserialisationTest PRIVATE CONAN_PKG::GTest CloveSerialisation)
+target_link_libraries(YamlDeserialisationTest PRIVATE CONAN_PKG::gtest CloveSerialisation)
 add_test(NAME YamlDeserialisationTest COMMAND YamlDeserialisationTest)

--- a/clove/components/utilities/delegate/tests/CMakeLists.txt
+++ b/clove/components/utilities/delegate/tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 #SingleCastDelegate
 add_executable(SingleCastDelegateTest SingleCastDelegateTests.cpp)
-target_link_libraries(SingleCastDelegateTest PRIVATE CONAN_PKG::GTest CloveDelegate)
+target_link_libraries(SingleCastDelegateTest PRIVATE CONAN_PKG::gtest CloveDelegate)
 add_test(NAME SingleCastDelegateTest COMMAND SingleCastDelegateTest)
 
 #MultiCastDelegate
 add_executable(MultiCastDelegateTest MultiCastDelegateTests.cpp)
-target_link_libraries(MultiCastDelegateTest PRIVATE CONAN_PKG::GTest CloveDelegate)
+target_link_libraries(MultiCastDelegateTest PRIVATE CONAN_PKG::gtest CloveDelegate)
 add_test(NAME MultiCastDelegateTest COMMAND MultiCastDelegateTest)

--- a/clove/components/utilities/event/tests/CMakeLists.txt
+++ b/clove/components/utilities/event/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(EventTest EventTests.cpp)
-target_link_libraries(EventTest PRIVATE CONAN_PKG::GTest CloveEvent)
+target_link_libraries(EventTest PRIVATE CONAN_PKG::gtest CloveEvent)
 add_test(NAME EventTest COMMAND EventTest)

--- a/clove/components/utilities/expected/tests/CMakeLists.txt
+++ b/clove/components/utilities/expected/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(ExpectedTest ExpectedTests.cpp)
-target_link_libraries(ExpectedTest PRIVATE CONAN_PKG::GTest CloveExpected)
+target_link_libraries(ExpectedTest PRIVATE CONAN_PKG::gtest CloveExpected)
 add_test(NAME ExpectedTest COMMAND ExpectedTest)

--- a/clove/components/utilities/memory/tests/CMakeLists.txt
+++ b/clove/components/utilities/memory/tests/CMakeLists.txt
@@ -1,14 +1,14 @@
 #StackAllocator
 add_executable(StackAllocatorTest StackAllocatorTests.cpp)
-target_link_libraries(StackAllocatorTest PRIVATE CONAN_PKG::GTest CloveMemory)
+target_link_libraries(StackAllocatorTest PRIVATE CONAN_PKG::gtest CloveMemory)
 add_test(NAME StackAllocatorTest COMMAND StackAllocatorTest)
 
 #ListAllocator
 add_executable(ListAllocatorTest ListAllocatorTests.cpp)
-target_link_libraries(ListAllocatorTest PRIVATE CONAN_PKG::GTest CloveMemory)
+target_link_libraries(ListAllocatorTest PRIVATE CONAN_PKG::gtest CloveMemory)
 add_test(NAME ListAllocatorTest COMMAND ListAllocatorTest)
 
 #PoolAllocator
 add_executable(PoolAllocatorTest PoolAllocatorTests.cpp)
-target_link_libraries(PoolAllocatorTest PRIVATE CONAN_PKG::GTest CloveMemory)
+target_link_libraries(PoolAllocatorTest PRIVATE CONAN_PKG::gtest CloveMemory)
 add_test(NAME PoolAllocatorTest COMMAND PoolAllocatorTest)

--- a/clove/tests/CMakeLists.txt
+++ b/clove/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(AssetPtrTest AssetPtrTests.cpp)
-target_link_libraries(AssetPtrTest PRIVATE CONAN_PKG::GTest Clove)
+target_link_libraries(AssetPtrTest PRIVATE CONAN_PKG::gtest Clove)
 add_test(NAME AssetPtrTest COMMAND AssetPtrTest)
 
 add_executable(VirtualFileSystem VirtualFileSystemTests.cpp)
-target_link_libraries(VirtualFileSystem PRIVATE CONAN_PKG::GTest Clove)
+target_link_libraries(VirtualFileSystem PRIVATE CONAN_PKG::gtest Clove)
 add_test(NAME VirtualFileSystem COMMAND VirtualFileSystem)


### PR DESCRIPTION
## Summary
This reverts commit 39ce56874e85494af499bbf053cebe68a1928def which was an attempt to fix build errors that hasn't worked
