### PR TITLE
Create an interface for the renderer class

### DIFF
--- a/clove/CMakeLists.txt
+++ b/clove/CMakeLists.txt
@@ -115,10 +115,10 @@ add_library(
 		${INCLUDE}/Rendering/Camera.hpp
 		${INCLUDE}/Rendering/Camera.inl
 		${SOURCE}/Rendering/Camera.cpp
-		${INCLUDE}/Rendering/ForwardRenderer3D.hpp
-		${SOURCE}/Rendering/ForwardRenderer3D.cpp
 		${INCLUDE}/Rendering/GraphicsImageRenderTarget.hpp
 		${SOURCE}/Rendering/GraphicsImageRenderTarget.cpp
+		${INCLUDE}/Rendering/HighDefinitionRenderer.hpp
+		${SOURCE}/Rendering/HighDefinitionRenderer.cpp
 		${INCLUDE}/Rendering/Material.hpp
 		${INCLUDE}/Rendering/Material.inl
 		${SOURCE}/Rendering/Material.cpp

--- a/clove/CMakeLists.txt
+++ b/clove/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library(
 		${INCLUDE}/Rendering/Material.hpp
 		${INCLUDE}/Rendering/Material.inl
 		${SOURCE}/Rendering/Material.cpp
+		${INCLUDE}/Rendering/Renderer.hpp
 		${INCLUDE}/Rendering/RenderingConstants.hpp
 		${INCLUDE}/Rendering/RenderingHelpers.hpp
 		${SOURCE}/Rendering/RenderingHelpers.cpp

--- a/clove/include/Clove/Application.hpp
+++ b/clove/include/Clove/Application.hpp
@@ -19,7 +19,7 @@ namespace clove {
     class Mouse;
     class Keyboard;
     class GhaDevice;
-    class ForwardRenderer3D;
+    class Renderer;
     class GraphicsImageRenderTarget;
     class AhaDevice;
     class PhysicsSubSystem;
@@ -47,7 +47,7 @@ namespace clove {
         Keyboard *keyboard{ nullptr };
         Mouse *mouse{ nullptr };
 
-        std::unique_ptr<ForwardRenderer3D> renderer;
+        std::unique_ptr<Renderer> renderer;
         EntityManager entityManager;
 
         VirtualFileSystem fileSystem{};
@@ -134,7 +134,7 @@ namespace clove {
         inline AhaDevice *getAudioDevice() const;
 
         //Systems
-        inline ForwardRenderer3D *getRenderer() const;
+        inline Renderer *getRenderer() const;
         inline EntityManager *getEntityManager();
 
         inline AssetManager *getAssetManager();

--- a/clove/include/Clove/Application.inl
+++ b/clove/include/Clove/Application.inl
@@ -79,7 +79,7 @@ namespace clove {
         return audioDevice.get();
     }
 
-    ForwardRenderer3D *Application::getRenderer() const {
+    Renderer *Application::getRenderer() const {
         return renderer.get();
     }
 

--- a/clove/include/Clove/Rendering/ForwardRenderer3D.hpp
+++ b/clove/include/Clove/Rendering/ForwardRenderer3D.hpp
@@ -2,8 +2,7 @@
 
 #include "Clove/Rendering/RenderGraph/RgFrameCache.hpp"
 #include "Clove/Rendering/RenderGraph/RgGlobalCache.hpp"
-#include "Clove/Rendering/RenderPasses/GeometryPass.hpp"
-#include "Clove/Rendering/ShaderBufferTypes.hpp"
+#include "Clove/Rendering/Renderer.hpp"
 
 #include <Clove/Delegate/DelegateHandle.hpp>
 #include <set>
@@ -19,19 +18,8 @@ namespace clove {
 }
 
 namespace clove {
-    class ForwardRenderer3D {
+    class ForwardRenderer3D : public Renderer{
         //TYPES
-    public:
-        //TODO: Currently transform and matrixPalet are copied per mesh for each model. This should be avoided
-        struct MeshInfo {
-            std::shared_ptr<Mesh> mesh;
-            std::shared_ptr<Material> material;
-            mat4f transform;
-            std::array<mat4f, MAX_JOINTS> matrixPalet;
-
-            std::set<GeometryPass::Id> geometryPassIds;
-        };
-
     private:
         //Data for an entire frame
         struct FrameData {
@@ -101,24 +89,24 @@ namespace clove {
 
         ~ForwardRenderer3D();
 
-        void begin();
+        void begin() override;
 
-        void submitMesh(MeshInfo meshInfo);
+        void submitMesh(MeshInfo meshInfo) override;
 
         /**
          * @brief Submit the active camera the renderer will use.
          */
-        void submitCamera(mat4f const view, mat4f const projection, vec3f const position);
+        void submitCamera(mat4f const view, mat4f const projection, vec3f const position) override;
 
-        void submitLight(DirectionalLight const &light);
-        void submitLight(PointLight const &light);
+        void submitLight(DirectionalLight const &light) override;
+        void submitLight(PointLight const &light) override;
 
-        void submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection);
-        void submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection);
+        void submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection) override;
+        void submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection) override;
 
-        void end();
+        void end() override;
 
-        vec2ui getRenderTargetSize() const;
+        vec2ui getRenderTargetSize() const override;
 
     private:
         void resetGraphCaches();

--- a/clove/include/Clove/Rendering/HighDefinitionRenderer.hpp
+++ b/clove/include/Clove/Rendering/HighDefinitionRenderer.hpp
@@ -18,7 +18,7 @@ namespace clove {
 }
 
 namespace clove {
-    class ForwardRenderer3D : public Renderer{
+    class HighDefinitionRenderer : public Renderer{
         //TYPES
     private:
         //Data for an entire frame
@@ -78,16 +78,16 @@ namespace clove {
 
         //FUNCTIONS
     public:
-        ForwardRenderer3D() = delete;
-        ForwardRenderer3D(GhaDevice *ghaDevice, std::unique_ptr<RenderTarget> renderTarget);
+        HighDefinitionRenderer() = delete;
+        HighDefinitionRenderer(GhaDevice *ghaDevice, std::unique_ptr<RenderTarget> renderTarget);
 
-        ForwardRenderer3D(ForwardRenderer3D const &other) = delete;
-        ForwardRenderer3D(ForwardRenderer3D &&other) noexcept;
+        HighDefinitionRenderer(HighDefinitionRenderer const &other) = delete;
+        HighDefinitionRenderer(HighDefinitionRenderer &&other) noexcept;
 
-        ForwardRenderer3D &operator=(ForwardRenderer3D const &other) = delete;
-        ForwardRenderer3D &operator=(ForwardRenderer3D &&other) noexcept;
+        HighDefinitionRenderer &operator=(HighDefinitionRenderer const &other) = delete;
+        HighDefinitionRenderer &operator=(HighDefinitionRenderer &&other) noexcept;
 
-        ~ForwardRenderer3D();
+        ~HighDefinitionRenderer();
 
         void begin() override;
 

--- a/clove/include/Clove/Rendering/Renderer.hpp
+++ b/clove/include/Clove/Rendering/Renderer.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Clove/Rendering/RenderPasses/GeometryPass.hpp"
+#include "Clove/Rendering/ShaderBufferTypes.hpp"
+
+#include <memory>
+#include <set>
+
+namespace clove {
+    class Mesh;
+    class Material;
+    class GhaImage;
+}
+
+namespace clove {
+    class Renderer {
+        //TYPES
+    public:
+        //TODO: Currently transform and matrixPalet are copied per mesh for each model. This should be avoided
+        struct MeshInfo {
+            std::shared_ptr<Mesh> mesh;
+            std::shared_ptr<Material> material;
+            mat4f transform;
+            std::array<mat4f, MAX_JOINTS> matrixPalet;
+
+            std::set<GeometryPass::Id> geometryPassIds;
+        };
+
+        //FUNCTIONS
+    public:
+        virtual ~Renderer() = default;
+
+        virtual void begin() = 0;
+
+        virtual void submitMesh(MeshInfo meshInfo) = 0;
+
+        /**
+         * @brief Submit the active camera the renderer will use.
+         */
+        virtual void submitCamera(mat4f const view, mat4f const projection, vec3f const position) = 0;
+
+        virtual void submitLight(DirectionalLight const &light) = 0;
+        virtual void submitLight(PointLight const &light)       = 0;
+
+        virtual void submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection) = 0;
+        virtual void submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection)     = 0;
+
+        virtual void end() = 0;
+
+        virtual vec2ui getRenderTargetSize() const = 0;
+    };
+}

--- a/clove/include/Clove/Rendering/Techniques/Technique.hpp
+++ b/clove/include/Clove/Rendering/Techniques/Technique.hpp
@@ -6,7 +6,6 @@
 
 namespace clove {
     class Mesh;
-    class ForwardRenderer3D;
 }
 
 namespace clove {

--- a/clove/include/Clove/SubSystems/RenderSubSystem.hpp
+++ b/clove/include/Clove/SubSystems/RenderSubSystem.hpp
@@ -5,7 +5,7 @@
 #include <Clove/DeltaTime.hpp>
 
 namespace clove {
-    class ForwardRenderer3D;
+    class Renderer;
     class EntityManager;
 }
 
@@ -13,13 +13,13 @@ namespace clove {
     class RenderSubSystem : public SubSystem {
         //VARIABLES
     private:
-        ForwardRenderer3D *renderer{ nullptr };
+        Renderer *renderer{ nullptr };
         EntityManager *entityManager{ nullptr };
 
         //FUNCTIONS
     public:
 		RenderSubSystem() = delete;
-        RenderSubSystem(ForwardRenderer3D *renderer, EntityManager *entityManager);
+        RenderSubSystem(Renderer *renderer, EntityManager *entityManager);
 
         RenderSubSystem(RenderSubSystem const &other) = delete;
         RenderSubSystem(RenderSubSystem &&other) noexcept;

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -135,11 +135,5 @@ namespace clove {
 
         //Systems
         renderer = std::make_unique<ForwardRenderer3D>(this->graphicsDevice.get(), std::move(renderTarget));
-
-        //SubSystems
-        //pushSubSystem<TransformSubSystem>(SubSystemGroup::Initialisation, &entityManager);
-        //pushSubSystem<PhysicsSubSystem>(SubSystemGroup::Initialisation, &entityManager);
-        //pushSubSystem<AudioSubSystem>(SubSystemGroup::Render, &entityManager);
-        //pushSubSystem<RenderSubSystem>(SubSystemGroup::Render, renderer.get(), &entityManager);
     }
 }

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -1,7 +1,7 @@
 #include "Clove/Application.hpp"
 
 #include "Clove/InputEvent.hpp"
-#include "Clove/Rendering/ForwardRenderer3D.hpp"
+#include "Clove/Rendering/HighDefinitionRenderer.hpp"
 #include "Clove/Rendering/GraphicsImageRenderTarget.hpp"
 #include "Clove/Rendering/SwapchainRenderTarget.hpp"
 #include "Clove/SubSystems/AudioSubSystem.hpp"
@@ -134,6 +134,6 @@ namespace clove {
         prevFrameTime = std::chrono::steady_clock::now();
 
         //Systems
-        renderer = std::make_unique<ForwardRenderer3D>(this->graphicsDevice.get(), std::move(renderTarget));
+        renderer = std::make_unique<HighDefinitionRenderer>(this->graphicsDevice.get(), std::move(renderTarget));
     }
 }

--- a/clove/source/Rendering/HighDefinitionRenderer.cpp
+++ b/clove/source/Rendering/HighDefinitionRenderer.cpp
@@ -1,4 +1,4 @@
-#include "Clove/Rendering/ForwardRenderer3D.hpp"
+#include "Clove/Rendering/HighDefinitionRenderer.hpp"
 
 #include "Clove/Application.hpp"
 #include "Clove/Rendering/Camera.hpp"
@@ -32,7 +32,7 @@ extern "C" const char font_p[];
 extern "C" const size_t font_pLength;
 
 namespace clove {
-    ForwardRenderer3D::ForwardRenderer3D(GhaDevice *ghaDevice, std::unique_ptr<RenderTarget> renderTarget)
+    HighDefinitionRenderer::HighDefinitionRenderer(GhaDevice *ghaDevice, std::unique_ptr<RenderTarget> renderTarget)
         : ghaDevice{ ghaDevice }
         , renderTarget{ std::move(renderTarget) }
         , globalCache{ ghaDevice->getGraphicsFactory() } {
@@ -55,7 +55,7 @@ namespace clove {
             frameCaches.emplace_back(ghaFactory, graphicsQueue.get(), computeQueue.get(), transferQueue.get());
         }
 
-        renderTargetPropertyChangedBeginHandle = this->renderTarget->onPropertiesChangedBegin.bind(&ForwardRenderer3D::resetGraphCaches, this);
+        renderTargetPropertyChangedBeginHandle = this->renderTarget->onPropertiesChangedBegin.bind(&HighDefinitionRenderer::resetGraphCaches, this);
 
         //Create semaphores for frame synchronisation
         for(auto &skinningFinishedSemaphore : skinningFinishedSemaphores) {
@@ -110,17 +110,17 @@ namespace clove {
         uiMesh = std::make_unique<Mesh>(uiVertices, uiIndices);
     }
 
-    ForwardRenderer3D::ForwardRenderer3D(ForwardRenderer3D &&other) noexcept = default;
+    HighDefinitionRenderer::HighDefinitionRenderer(HighDefinitionRenderer &&other) noexcept = default;
 
-    ForwardRenderer3D &ForwardRenderer3D::operator=(ForwardRenderer3D &&other) noexcept = default;
+    HighDefinitionRenderer &HighDefinitionRenderer::operator=(HighDefinitionRenderer &&other) noexcept = default;
 
-    ForwardRenderer3D::~ForwardRenderer3D() {
+    HighDefinitionRenderer::~HighDefinitionRenderer() {
         //Wait for an idle device before implicitly destructing the render graph caches.
         //This prevents issues when trying to destroy objects while they might still be in use.
         ghaDevice->waitForIdleDevice();
     }
 
-    void ForwardRenderer3D::begin() {
+    void HighDefinitionRenderer::begin() {
         currentFrameData.meshes.clear();
         currentFrameData.widgets.clear();
         currentFrameData.text.clear();
@@ -133,40 +133,40 @@ namespace clove {
         }
     }
 
-    void ForwardRenderer3D::submitMesh(MeshInfo meshInfo) {
+    void HighDefinitionRenderer::submitMesh(MeshInfo meshInfo) {
         currentFrameData.meshes.push_back(std::move(meshInfo));
     }
 
-    void ForwardRenderer3D::submitCamera(mat4f const view, mat4f const projection, vec3f const position) {
+    void HighDefinitionRenderer::submitCamera(mat4f const view, mat4f const projection, vec3f const position) {
         currentFrameData.viewData.view       = view;
         currentFrameData.viewData.projection = projection;
 
         currentFrameData.viewPosition = position;
     }
 
-    void ForwardRenderer3D::submitLight(DirectionalLight const &light) {
+    void HighDefinitionRenderer::submitLight(DirectionalLight const &light) {
         uint32_t const lightIndex{ currentFrameData.numLights.numDirectional++ };
 
         currentFrameData.lights.directionalLights[lightIndex]    = light.data;
         currentFrameData.directionalShadowTransforms[lightIndex] = light.shadowTransform;
     }
 
-    void ForwardRenderer3D::submitLight(PointLight const &light) {
+    void HighDefinitionRenderer::submitLight(PointLight const &light) {
         uint32_t const lightIndex{ currentFrameData.numLights.numPoint++ };
 
         currentFrameData.lights.pointLights[lightIndex]    = light.data;
         currentFrameData.pointShadowTransforms[lightIndex] = light.shadowTransforms;
     }
 
-    void ForwardRenderer3D::submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection) {
+    void HighDefinitionRenderer::submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection) {
         currentFrameData.widgets.emplace_back(std::move(widget), modelProjection);
     }
 
-    void ForwardRenderer3D::submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection) {
+    void HighDefinitionRenderer::submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection) {
         currentFrameData.text.emplace_back(std::move(text), modelProjection);
     }
 
-    void ForwardRenderer3D::end() {
+    void HighDefinitionRenderer::end() {
         framesInFlight[currentFrame]->wait();
 
         //Aquire the next available image from the render target
@@ -528,11 +528,11 @@ namespace clove {
         currentFrame = (currentFrame + 1) % maxFramesInFlight;
     }
 
-    vec2ui ForwardRenderer3D::getRenderTargetSize() const {
+    vec2ui HighDefinitionRenderer::getRenderTargetSize() const {
         return renderTarget->getSize();
     }
 
-    void ForwardRenderer3D::resetGraphCaches() {
+    void HighDefinitionRenderer::resetGraphCaches() {
         ghaDevice->waitForIdleDevice();
 
         for(auto &cache : frameCaches) {

--- a/clove/source/SubSystems/RenderSubSystem.cpp
+++ b/clove/source/SubSystems/RenderSubSystem.cpp
@@ -7,7 +7,7 @@
 #include "Clove/Components/PointLightComponent.hpp"
 #include "Clove/Components/StaticModelComponent.hpp"
 #include "Clove/Components/TransformComponent.hpp"
-#include "Clove/Rendering/ForwardRenderer3D.hpp"
+#include "Clove/Rendering/Renderer.hpp"
 #include "Clove/Rendering/Renderables/Mesh.hpp"
 
 #include <Clove/ECS/EntityManager.hpp>
@@ -15,7 +15,7 @@
 #include <Clove/Maths/MathsHelpers.hpp>
 
 namespace clove {
-    RenderSubSystem::RenderSubSystem(ForwardRenderer3D *renderer, EntityManager *entityManager)
+    RenderSubSystem::RenderSubSystem(Renderer *renderer, EntityManager *entityManager)
         : SubSystem("Render")
         , renderer{ renderer }
         , entityManager{ entityManager } {
@@ -63,7 +63,7 @@ namespace clove {
                     passIds.insert(technique.passIds.begin(), technique.passIds.end());
                 }
                 for(auto const &mesh : staticModel.model->getMeshes()) {
-                    renderer->submitMesh(ForwardRenderer3D::MeshInfo{ mesh, staticModel.material, modelTransform, matrixPalet, passIds });
+                    renderer->submitMesh(Renderer::MeshInfo{ mesh, staticModel.material, modelTransform, matrixPalet, passIds });
                 }
             }
         });
@@ -78,7 +78,7 @@ namespace clove {
                     passIds.insert(technique.passIds.begin(), technique.passIds.end());
                 }
                 for(auto const &mesh : animatedModel.model->getMeshes()) {
-                    renderer->submitMesh(ForwardRenderer3D::MeshInfo{ mesh, animatedModel.material, modelTransform, matrixPalet, passIds });
+                    renderer->submitMesh(Renderer::MeshInfo{ mesh, animatedModel.material, modelTransform, matrixPalet, passIds });
                 }
             }
         });

--- a/clove/source/UI/Image.cpp
+++ b/clove/source/UI/Image.cpp
@@ -1,7 +1,7 @@
 #include "Clove/UI/Image.hpp"
 
 #include "Clove/Application.hpp"
-#include "Clove/Rendering/ForwardRenderer3D.hpp"
+#include "Clove/Rendering/Renderer.hpp"
 #include "Clove/Rendering/RenderingHelpers.hpp"
 
 #include <Clove/Graphics/GhaDevice.hpp>

--- a/clove/source/UI/Text.cpp
+++ b/clove/source/UI/Text.cpp
@@ -1,7 +1,7 @@
 #include "Clove/UI/Text.hpp"
 
 #include "Clove/Application.hpp"
-#include "Clove/Rendering/ForwardRenderer3D.hpp"
+#include "Clove/Rendering/Renderer.hpp"
 
 #include <Clove/Maths/MathsHelpers.hpp>
 


### PR DESCRIPTION
## Summary
Set up an interface for the renderer. Allowing Clove to easily switch between different renderers in the future.

## Changes
- Created an interface for the renderer.
- Rename `ForwardRenderer3D` -> `HighDefinitionRenderer`