### PR TITLE
Feature/forward+

### DIFF
--- a/clove/CMakeLists.txt
+++ b/clove/CMakeLists.txt
@@ -30,6 +30,9 @@ set(
 		${SOURCE}/Shaders/PointShadowDepthsVert.glsl
 		${SOURCE}/Shaders/PointShadowDepthsPixel.glsl
 
+		${SOURCE}/Shaders/SceneDepthVert.glsl
+		${SOURCE}/Shaders/SceneDepthPixel.glsl
+
 		${SOURCE}/Shaders/UIVert.glsl
 		${SOURCE}/Shaders/WidgetPixel.glsl
 		${SOURCE}/Shaders/FontPixel.glsl

--- a/clove/CMakeLists.txt
+++ b/clove/CMakeLists.txt
@@ -16,11 +16,14 @@ find_package(SndFile REQUIRED CONFIG)
 #Prepare SOURCEs to be inbedded
 set(
 	ShaderIncludes
+		${SOURCE}/Shaders/Common.glsl
 		${SOURCE}/Shaders/Constants.glsl
 )
 
 set(
 	ShaderFiles
+		${SOURCE}/Shaders/ComputeLightGridCompute.glsl
+
 		${SOURCE}/Shaders/ForwardPassVert.glsl
 		${SOURCE}/Shaders/ForwardPassPixel.glsl
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Descriptor.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Descriptor.hpp
@@ -5,6 +5,7 @@ namespace clove {
         UniformBuffer,
         StorageBuffer,
         SampledImage,
+        StorageImage,
         Sampler,
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaBuffer.hpp
@@ -18,8 +18,8 @@ namespace clove {
             TransferDestination = 1 << 1, /**< To be used as a destination in a transfer operation. */
             VertexBuffer        = 1 << 2,
             IndexBuffer         = 1 << 3,
-            UniformBuffer       = 1 << 4, /**< Uploaded to shaders as a uniform buffer object (UBO). */
-            StorageBuffer       = 1 << 5, /**< Uploaded to shaders as a storage buffer object (SSBO). */
+            UniformBuffer       = 1 << 4, /**< Uploaded to shaders as a uniform buffer object (Read only data). */
+            StorageBuffer       = 1 << 5, /**< Uploaded to shaders as a storage buffer object (ReadWrite from compute). */
         };
 
         struct Descriptor {

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaDescriptorSet.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaDescriptorSet.hpp
@@ -36,6 +36,7 @@ namespace clove {
          * @param buffer The buffer to write from.
          * @param offset An offset into the buffer to start writting from.
          * @param range The size of the region into the buffer to write.
+         * @param descriptorType Type of descriptor that is being written.
          * @param bindingSlot The binding slot inside the shader to write to.
          */
         virtual void write(GhaBuffer const &buffer, size_t const offset, size_t const range, DescriptorType const descriptorType, uint32_t const bindingSlot) = 0;
@@ -45,9 +46,10 @@ namespace clove {
          * @details The value that is read from the shader will be whatever value is in the image at the time of writing.
          * @param imageView The image view to write.
          * @param layout The layout of the image being written.
+         * @param descriptorType Type of descriptor that is being written.
          * @param bindingSlot The binding slot inside the shader to write to.
          */
-        virtual void write(GhaImageView const &imageView, GhaImage::Layout const layout, uint32_t const bindingSlot) = 0;
+        virtual void write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) = 0;
 
         /**
          * @brief Writes a sampler into a binding inside a shader.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaImage.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaImage.hpp
@@ -34,6 +34,7 @@ namespace clove {
             Unkown,
 
             R8_UNORM,
+            R32G32_UINT,
             R8G8B8A8_SRGB,
             B8G8R8A8_SRGB,
             B8G8R8A8_UNORM,

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaImage.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaImage.hpp
@@ -19,9 +19,10 @@ namespace clove {
         enum class UsageMode : UsageModeType {
             TransferSource         = 1 << 0, /**< To be used as a source in a transfer operation. */
             TransferDestination    = 1 << 1, /**< To be used as a destination in a transfer operation. Such as writing data from a system memory backed buffer to a video memory backed buffer */
-            Sampled                = 1 << 2, /**< To be used in a GhaImageView that's sampled in a shader */
-            ColourAttachment       = 1 << 3, /**< To be used in a GhaImageView for a frame buffer */
-            DepthStencilAttachment = 1 << 4, /**< To be used in a GhaImageView for a depth / stencil attachment */
+            Sampled                = 1 << 2, /**< To be used in a GhaImage that'll be sampled in a shader */
+            Storage                = 1 << 3, /**< To be used in a GhaImage that requires unorderred acces (such as writing from a compute shader) */
+            ColourAttachment       = 1 << 4, /**< To be used in a GhaImage for a frame buffer */
+            DepthStencilAttachment = 1 << 5, /**< To be used in a GhaImage for a depth / stencil attachment */
         };
 
         enum class Type {

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaImage.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaImage.hpp
@@ -19,7 +19,7 @@ namespace clove {
         enum class UsageMode : UsageModeType {
             TransferSource         = 1 << 0, /**< To be used as a source in a transfer operation. */
             TransferDestination    = 1 << 1, /**< To be used as a destination in a transfer operation. Such as writing data from a system memory backed buffer to a video memory backed buffer */
-            Sampled                = 1 << 2, /**< To be used in a GhaImage that'll be sampled in a shader */
+            Sampled                = 1 << 2, /**< To be used in a GhaImage that'll be sampled in a shader (read only) */
             Storage                = 1 << 3, /**< To be used in a GhaImage that requires unorderred acces (such as writing from a compute shader) */
             ColourAttachment       = 1 << 4, /**< To be used in a GhaImage for a frame buffer */
             DepthStencilAttachment = 1 << 5, /**< To be used in a GhaImage for a depth / stencil attachment */

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorSet.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalDescriptorSet.hpp
@@ -46,7 +46,7 @@ namespace clove {
 
         void write(GhaBuffer const &buffer, size_t const offset, size_t const range, DescriptorType const descriptorType, uint32_t const bindingSlot) override;
 
-        void write(GhaImageView const &imageView, GhaImage::Layout const layout, uint32_t const bindingSlot) override;
+        void write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) override;
 
         void write(GhaSampler const &sampler, uint32_t const bindingSlot) override;
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
 namespace clove {
+    class GhaBuffer;
+    class GhaImageView;
+}
+
+namespace clove {
     template<typename BaseDescriptorSetType>
     class ValidationDescriptorSet : public BaseDescriptorSetType {
         //FUNCTIONS

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.hpp
@@ -8,6 +8,7 @@ namespace clove {
         using BaseDescriptorSetType::BaseDescriptorSetType;
 
         void write(GhaBuffer const &buffer, size_t const offset, size_t const range, DescriptorType const descriptorType, uint32_t const bindingSlot) override;
+        void write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) override;
     };
 }
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.inl
@@ -3,8 +3,16 @@
 namespace clove {
     template<typename BaseDescriptorSetType>
     void ValidationDescriptorSet<BaseDescriptorSetType>::write(GhaBuffer const &buffer, size_t const offset, size_t const range, DescriptorType const descriptorType, uint32_t const bindingSlot) {
-        CLOVE_ASSERT_MSG(range > 0, "{0}: 'range' value cannot be 0.");
+        CLOVE_ASSERT_MSG(range > 0, "{0}: 'range' value cannot be 0.", CLOVE_FUNCTION_NAME);
+
+        CLOVE_ASSERT_MSG(descriptorType == DescriptorType::UniformBuffer || descriptorType == DescriptorType::StorageBuffer, "{0}: Invalid descriptor type for buffer.", CLOVE_FUNCTION_NAME);
 
         BaseDescriptorSetType::write(buffer, offset, range, descriptorType, bindingSlot);
+    }
+
+    void ValidationDescriptorSet<BaseDescriptorSetType>::write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) {
+        CLOVE_ASSERT_MSG(descriptorType == DescriptorType::SampledImage || descriptorType == DescriptorType::StorageImage, "{0}: Invalid descriptor type for image.", CLOVE_FUNCTION_NAME);
+
+        BaseDescriptorSetType::write(imageView, layout, descriptorType, bindingSlot);
     }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationDescriptorSet.inl
@@ -10,6 +10,7 @@ namespace clove {
         BaseDescriptorSetType::write(buffer, offset, range, descriptorType, bindingSlot);
     }
 
+    template<typename BaseDescriptorSetType>
     void ValidationDescriptorSet<BaseDescriptorSetType>::write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) {
         CLOVE_ASSERT_MSG(descriptorType == DescriptorType::SampledImage || descriptorType == DescriptorType::StorageImage, "{0}: Invalid descriptor type for image.", CLOVE_FUNCTION_NAME);
 

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDescriptorSet.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanDescriptorSet.hpp
@@ -27,7 +27,7 @@ namespace clove {
 
         void write(GhaBuffer const &buffer, size_t const offset, size_t const range, DescriptorType const descriptorType, uint32_t const bindingSlot) override;
 
-        void write(GhaImageView const &imageView, GhaImage::Layout const layout, uint32_t const bindingSlot) override;
+        void write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) override;
 
         void write(GhaSampler const &sampler, uint32_t const bindingSlot) override;
 

--- a/clove/components/core/graphics/source/Metal/MetalDescriptorSet.mm
+++ b/clove/components/core/graphics/source/Metal/MetalDescriptorSet.mm
@@ -43,7 +43,7 @@ namespace clove {
         }
     }
     
-    void MetalDescriptorSet::write(GhaImageView const &imageView, GhaImage::Layout const layout, uint32_t const bindingSlot) {
+    void MetalDescriptorSet::write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) {
         [pixelEncoder->encoder setTexture:polyCast<MetalImageView const>(&imageView)->getTexture()
                                   atIndex:bindingSlot];
     }

--- a/clove/components/core/graphics/source/Metal/MetalFactory.mm
+++ b/clove/components/core/graphics/source/Metal/MetalFactory.mm
@@ -316,7 +316,7 @@ namespace clove {
         MTLDepthStencilDescriptor *depthStencil{ [[MTLDepthStencilDescriptor alloc] init] };
         depthStencil.depthWriteEnabled = static_cast<BOOL>(descriptor.depthState.depthWrite);
         if(descriptor.depthState.depthTest){
-            depthStencil.depthCompareFunction = MTLCompareFunctionLess;
+            depthStencil.depthCompareFunction = MTLCompareFunctionLessEqual;
         }else{
             depthStencil.depthCompareFunction = MTLCompareFunctionAlways;
         }

--- a/clove/components/core/graphics/source/Metal/MetalFactory.mm
+++ b/clove/components/core/graphics/source/Metal/MetalFactory.mm
@@ -79,6 +79,9 @@ namespace clove {
             if((flags & GhaImage::UsageMode::Sampled) != 0) {
                 mtlFlags |= MTLTextureUsageShaderRead;
             }
+            if((flags & GhaImage::UsageMode::Storage) != 0) {
+                mtlFlags |= MTLTextureUsageShaderWrite;
+            }
             if((flags & GhaImage::UsageMode::ColourAttachment) != 0) {
                 mtlFlags |= MTLTextureUsageRenderTarget;
             }

--- a/clove/components/core/graphics/source/Metal/MetalImage.mm
+++ b/clove/components/core/graphics/source/Metal/MetalImage.mm
@@ -30,6 +30,8 @@ namespace clove {
                 return MTLPixelFormatInvalid;
             case Format::R8_UNORM:
                 return MTLPixelFormatR8Unorm;
+            case Format::R32G32_UINT:
+                return MTLPixelFormatRG32Uint;
             case Format::R8G8B8A8_SRGB:
                 return MTLPixelFormatRGBA8Unorm_sRGB;
             case Format::B8G8R8A8_SRGB:

--- a/clove/components/core/graphics/source/Vulkan/VulkanDescriptor.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDescriptor.cpp
@@ -11,6 +11,8 @@ namespace clove {
                 return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             case DescriptorType::SampledImage:
                 return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+            case DescriptorType::StorageImage:
+                return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             case DescriptorType::Sampler:
                 return VK_DESCRIPTOR_TYPE_SAMPLER;
             default:

--- a/clove/components/core/graphics/source/Vulkan/VulkanDescriptorSet.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDescriptorSet.cpp
@@ -45,13 +45,15 @@ namespace clove {
         vkUpdateDescriptorSets(device, 1, &writeInfo, 0, nullptr);
     }
 
-    void VulkanDescriptorSet::write(GhaImageView const &imageView, GhaImage::Layout const layout, uint32_t const bindingSlot) {
+    void VulkanDescriptorSet::write(GhaImageView const &imageView, GhaImage::Layout const layout, DescriptorType const descriptorType, uint32_t const bindingSlot) {
         auto const *vkImageView{ polyCast<VulkanImageView const>(&imageView) };
 
         VkDescriptorImageInfo imageInfo{
             .imageView   = vkImageView->getImageView(),
             .imageLayout = VulkanImage::convertLayout(layout),
         };
+
+        VkDescriptorType const descriptorType{};
 
         VkWriteDescriptorSet writeInfo{
             .sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
@@ -60,7 +62,7 @@ namespace clove {
             .dstBinding       = bindingSlot,
             .dstArrayElement  = 0,
             .descriptorCount  = 1,
-            .descriptorType   = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+            .descriptorType   = getDescriptorType(descriptorType),
             .pImageInfo       = &imageInfo,
             .pBufferInfo      = nullptr,
             .pTexelBufferView = nullptr,

--- a/clove/components/core/graphics/source/Vulkan/VulkanDescriptorSet.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanDescriptorSet.cpp
@@ -53,8 +53,6 @@ namespace clove {
             .imageLayout = VulkanImage::convertLayout(layout),
         };
 
-        VkDescriptorType const descriptorType{};
-
         VkWriteDescriptorSet writeInfo{
             .sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
             .pNext            = nullptr,

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -804,7 +804,7 @@ namespace clove {
             .flags                 = 0,
             .depthTestEnable       = static_cast<VkBool32>(descriptor.depthState.depthTest ? VK_TRUE : VK_FALSE),
             .depthWriteEnable      = static_cast<VkBool32>(descriptor.depthState.depthWrite ? VK_TRUE : VK_FALSE),
-            .depthCompareOp        = VK_COMPARE_OP_LESS,
+            .depthCompareOp        = VK_COMPARE_OP_LESS_OR_EQUAL,
             .depthBoundsTestEnable = VK_FALSE,
             .stencilTestEnable     = VK_FALSE,
             .front                 = {},

--- a/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanFactory.cpp
@@ -170,6 +170,9 @@ namespace clove {
             if((garlicUsageFlags & GhaImage::UsageMode::Sampled) != 0) {
                 flags |= VK_IMAGE_USAGE_SAMPLED_BIT;
             }
+            if((garlicUsageFlags & GhaImage::UsageMode::Storage) != 0) {
+                flags |= VK_IMAGE_USAGE_STORAGE_BIT;
+            }
             if((garlicUsageFlags & GhaImage::UsageMode::ColourAttachment) != 0) {
                 flags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
             }

--- a/clove/components/core/graphics/source/Vulkan/VulkanImage.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanImage.cpp
@@ -61,6 +61,8 @@ namespace clove {
                 return VK_FORMAT_UNDEFINED;
             case Format::R8_UNORM:
                 return VK_FORMAT_R8_UNORM;
+            case Format::R32G32_UINT:
+                return VK_FORMAT_R32G32_UINT;
             case Format::R8G8B8A8_SRGB:
                 return VK_FORMAT_R8G8B8A8_SRGB;
             case Format::B8G8R8A8_SRGB:

--- a/clove/include/Clove/Rendering/HighDefinitionRenderer.hpp
+++ b/clove/include/Clove/Rendering/HighDefinitionRenderer.hpp
@@ -41,6 +41,16 @@ namespace clove {
             std::vector<std::pair<std::shared_ptr<GhaImage>, mat4f>> text;
         };
 
+        struct ViewUniformBufferData{
+            RgBufferId buffer;
+
+            size_t viewDataSize;
+            size_t viewPositionSize;
+
+            size_t viewDataOffset;
+            size_t viewPositionOffset;
+        };
+
         struct RenderGraphMeshInfo {
             size_t meshIndex{};
 
@@ -133,9 +143,13 @@ namespace clove {
         vec2ui getRenderTargetSize() const override;
 
     private:
+        RgImageId renderSceneDepth(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, ViewUniformBufferData const &viewUniformBuffer);
+
         void skinMeshes(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> &meshes);
+
         RenderGraphShadowMaps renderShadowDepths(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes);
-        void renderSene(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, RenderGraphShadowMaps const shadowMaps, RgImageId const renderTarget, RgImageId const depthTarget);
+
+        void renderSene(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, ViewUniformBufferData const &viewUniformBuffer, RenderGraphShadowMaps const shadowMaps, RgImageId const renderTarget, RgImageId const depthTarget);
 
         void resetGraphCaches();
     };

--- a/clove/include/Clove/Rendering/HighDefinitionRenderer.hpp
+++ b/clove/include/Clove/Rendering/HighDefinitionRenderer.hpp
@@ -21,19 +21,19 @@ namespace clove {
 }
 
 namespace clove {
-    class HighDefinitionRenderer : public Renderer{
+    class HighDefinitionRenderer : public Renderer {
         //TYPES
     private:
         struct FrameData {
             ViewData viewData;
             vec3f viewPosition;
 
-            LightDataArray lights;
-            DirectionalShadowTransformArray directionalShadowTransforms;
+            uint32_t numDirLights{ 0 };
+            uint32_t numPointLights{ 0 };
 
-            LightCount numLights;
-
-            std::array<std::array<mat4f, 6>, MAX_LIGHTS> pointShadowTransforms;
+            std::vector<LightData> lights;
+            std::vector<mat4f> directionalShadowTransforms;
+            std::vector<std::array<mat4f, 6>> pointShadowTransforms;
 
             std::vector<MeshInfo> meshes;
 
@@ -41,7 +41,7 @@ namespace clove {
             std::vector<std::pair<std::shared_ptr<GhaImage>, mat4f>> text;
         };
 
-        struct ViewUniformBufferData{
+        struct ViewUniformBufferData {
             RgBufferId buffer;
 
             size_t viewDataSize;
@@ -49,6 +49,22 @@ namespace clove {
 
             size_t viewDataOffset;
             size_t viewPositionOffset;
+        };
+
+        struct LightBuffers {
+            RgBufferId lightsBuffer;    /**< Contains the Light data struct for each light in the scene. */
+            RgBufferId lightDataBuffer; /**< Contains info about the lights (how many there are etc). */
+
+            size_t lightsSize{};
+
+            size_t dirLightCountOffset{};
+            size_t dirLightCountSize{};
+
+            size_t dirShadowTransformsOffset{};
+            size_t dirShadowTransformsSize{};
+
+            size_t totalLightOffset{};
+            size_t totalLightSize{};
         };
 
         struct RenderGraphMeshInfo {
@@ -73,9 +89,16 @@ namespace clove {
             RgSampler materialSampler{};
         };
 
-        struct RenderGraphShadowMaps{
+        struct RenderGraphShadowMaps {
             RgImageId directionalShadowMap;
             RgImageId pointShadowMap;
+        };
+
+        struct LightGrid {
+            RgImageId lightGrid;
+            RgBufferId lightIndexList;
+
+            size_t lightIndexListSize{ 0 };
         };
 
         //VARIABLES
@@ -132,8 +155,8 @@ namespace clove {
          */
         void submitCamera(mat4f const view, mat4f const projection, vec3f const position) override;
 
-        void submitLight(DirectionalLight const &light) override;
-        void submitLight(PointLight const &light) override;
+        void submitLight(DirectionalLight light) override;
+        void submitLight(PointLight light) override;
 
         void submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection) override;
         void submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection) override;
@@ -145,11 +168,12 @@ namespace clove {
     private:
         RgImageId renderSceneDepth(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, ViewUniformBufferData const &viewUniformBuffer);
 
+        LightGrid computeLightGrid(RenderGraph &renderGraph, LightBuffers const &lightBuffers, RgImageId const sceneDepth);
         void skinMeshes(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> &meshes);
 
         RenderGraphShadowMaps renderShadowDepths(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes);
 
-        void renderSene(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, ViewUniformBufferData const &viewUniformBuffer, RenderGraphShadowMaps const shadowMaps, RgImageId const renderTarget, RgImageId const depthTarget);
+        void renderSene(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, ViewUniformBufferData const &viewUniformBuffer, LightGrid const &lightGrid, LightBuffers const &lightBuffers, RenderGraphShadowMaps const shadowMaps, RgImageId const renderTarget, RgImageId const depthTarget);
 
         void resetGraphCaches();
     };

--- a/clove/include/Clove/Rendering/RenderGraph/RgComputePass.hpp
+++ b/clove/include/Clove/Rendering/RenderGraph/RgComputePass.hpp
@@ -25,6 +25,9 @@ namespace clove {
 
             std::vector<RgBufferBinding> writeBuffers{};
 
+            std::vector<RgImageBinding> readImages{};
+            std::vector<RgImageBinding> writeImages{};
+
             vec3ui disptachSize{};
         };
 

--- a/clove/include/Clove/Rendering/RenderGraph/RgComputePass.hpp
+++ b/clove/include/Clove/Rendering/RenderGraph/RgComputePass.hpp
@@ -25,8 +25,10 @@ namespace clove {
 
             std::vector<RgBufferBinding> writeBuffers{};
 
-            std::vector<RgImageBinding> readImages{};
-            std::vector<RgImageBinding> writeImages{};
+            std::vector<RgImageBinding> readImages{};/**< Read images will require samplers */
+            std::vector<RgImageBinding> writeImages{}; 
+
+            std::vector<RgSamplerBinding> samplers{};
 
             vec3ui disptachSize{};
         };

--- a/clove/include/Clove/Rendering/RenderGraph/RgRenderPass.hpp
+++ b/clove/include/Clove/Rendering/RenderGraph/RgRenderPass.hpp
@@ -45,9 +45,11 @@ namespace clove {
             RgResourceId vertexBuffer{};
             RgResourceId indexBuffer{};
 
-            std::vector<RgBufferBinding> shaderUbos{};
-            std::vector<RgImageBinding> shaderImages{};
-            std::vector<RgSamplerBinding> shaderSamplers{};
+            std::vector<RgBufferBinding> readUniformBuffers{};
+            std::vector<RgBufferBinding> readStorageBuffers{};
+
+            std::vector<RgImageBinding> images{};
+            std::vector<RgSamplerBinding> samplers{};
 
             size_t indexCount{ 0 };
         };

--- a/clove/include/Clove/Rendering/Renderer.hpp
+++ b/clove/include/Clove/Rendering/Renderer.hpp
@@ -16,6 +16,16 @@ namespace clove {
     class Renderer {
         //TYPES
     public:
+        struct DirectionalLight {
+            LightData data{};
+            mat4f shadowTransform{};
+        };
+
+        struct PointLight {
+            LightData data{};
+            std::array<mat4f, 6> shadowTransforms{};
+        };
+
         //TODO: Currently transform and matrixPalet are copied per mesh for each model. This should be avoided
         struct MeshInfo {
             std::shared_ptr<Mesh> mesh;
@@ -37,8 +47,8 @@ namespace clove {
          */
         virtual void submitCamera(mat4f const view, mat4f const projection, vec3f const position) = 0;
 
-        virtual void submitLight(DirectionalLight const &light) = 0;
-        virtual void submitLight(PointLight const &light)       = 0;
+        virtual void submitLight(DirectionalLight light) = 0;
+        virtual void submitLight(PointLight light)       = 0;
 
         virtual void submitWidget(std::shared_ptr<GhaImage> widget, mat4f const modelProjection) = 0;
         virtual void submitText(std::shared_ptr<GhaImage> text, mat4f const modelProjection)     = 0;

--- a/clove/include/Clove/Rendering/RenderingConstants.hpp
+++ b/clove/include/Clove/Rendering/RenderingConstants.hpp
@@ -7,8 +7,10 @@
 
 namespace clove {
 	//Variables present in Constants.glsl
-    inline uint8_t constexpr MAX_LIGHTS{ 10u };
     inline uint8_t constexpr MAX_JOINTS{ std::numeric_limits<JointIndexType>::max() };
+
+    inline uint32_t constexpr LIGHT_TYPE_DIRECTIONAL{ 0 };
+    inline uint32_t constexpr LIGHT_TYPE_POINT{ 1 };
 
     //General constants
     inline uint32_t constexpr shadowMapSize{ 1024u };

--- a/clove/include/Clove/Rendering/ShaderBufferTypes.hpp
+++ b/clove/include/Clove/Rendering/ShaderBufferTypes.hpp
@@ -22,51 +22,26 @@ namespace clove {
     };
 
     //Lighting data passed to GPU
-    struct DirectionalLightData {
-        alignas(16) vec3f direction{ 0.0f, 0.0f, 0.0f };
+    struct LightData {
+        vec3f direction{ 0.0f, 0.0f, 0.0f };
+        uint32_t shadowIndex{ 0 };
 
-        alignas(16) vec3f ambient{ 0.01f, 0.01f, 0.01f };
-        alignas(16) vec3f diffuse{ 0.75f, 0.75f, 0.75f };
-        alignas(16) vec3f specular{ 1.0f, 1.0f, 1.0f };
-    };
-    struct PointLightData {
         vec3f position{ 0.0f, 0.0f, 0.0f };
-
         float constant{ 1.0f };
+
         vec3f ambient{ 0.01f, 0.01f, 0.01f };
         float linear{ 0.0014f };
+
         vec3f diffuse{ 0.75f, 0.75f, 0.75f };
         float quadratic{ 0.000007f };
+
         vec3f specular{ 1.0f, 1.0f, 1.0f };
+        float radius{ 0 };
 
-        float farPlane{ 0 };
-    };
-    struct LightDataArray {
-        std::array<DirectionalLightData, MAX_LIGHTS> directionalLights{};
-        std::array<PointLightData, MAX_LIGHTS> pointLights{};
-    };
-
-    struct LightCount {
-        uint32_t numDirectional{ 0 };
-        uint32_t numPoint{ 0 };
-    };
-
-    //Lighting data needed shadows
-    struct DirectionalShadowTransformArray {
-        std::array<mat4f, MAX_LIGHTS> transforms;
-        mat4f &operator[](const size_t index) {
-            return transforms[index];
-        }
-    };
-
-    //For renderer - TODO Move into that header
-    struct DirectionalLight {
-        DirectionalLightData data{};
-        mat4f shadowTransform{};
-    };
-    struct PointLight {
-        PointLightData data{};
-        std::array<mat4f, 6> shadowTransforms{};
+        int32_t type{ 0 };
+        float padding_1;
+        float padding_2;
+        float padding_3;
     };
 
     struct SkeletalData {

--- a/clove/source/Rendering/HighDefinitionRenderer.cpp
+++ b/clove/source/Rendering/HighDefinitionRenderer.cpp
@@ -164,6 +164,8 @@ namespace clove {
     }
 
     void HighDefinitionRenderer::submitLight(DirectionalLight light) {
+        CLOVE_ASSERT_MSG(currentFrameData.numDirLights == 0, "Currently only supporting a single directional lights");
+
         uint32_t const dirLightIndex{ currentFrameData.numDirLights++ };
 
         light.data.shadowIndex = dirLightIndex;
@@ -693,7 +695,7 @@ namespace clove {
     }
 
     HighDefinitionRenderer::RenderGraphShadowMaps HighDefinitionRenderer::renderShadowDepths(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes) {
-        RgImageId directionalShadowMap{ renderGraph.createImage(GhaImage::Type::_2D, GhaImage::Format::D32_SFLOAT, { shadowMapSize, shadowMapSize }, currentFrameData.numDirLights) };
+        RgImageId directionalShadowMap{ renderGraph.createImage(GhaImage::Type::_2D, GhaImage::Format::D32_SFLOAT, { shadowMapSize, shadowMapSize }) };
         RgImageId pointShadowMap{ renderGraph.createImage(GhaImage::Type::Cube, GhaImage::Format::D32_SFLOAT, { shadowMapSize, shadowMapSize }, currentFrameData.numPointLights) };
 
         //Directional lights
@@ -722,8 +724,7 @@ namespace clove {
                     .storeOp    = StoreOperation::Store,
                     .clearValue = DepthStencilValue{ .depth = 1.0f },
                     .imageView  = {
-                        .image      = directionalShadowMap,
-                        .arrayIndex = static_cast<uint32_t>(light.shadowIndex),
+                        .image = directionalShadowMap,
                     },
                 }
             };
@@ -957,8 +958,7 @@ namespace clove {
                                                                 RgImageBinding{
                                                                     .slot      = 7,//NOLINT
                                                                     .imageView = {
-                                                                        .image      = shadowMaps.directionalShadowMap,
-                                                                        .arrayCount = currentFrameData.numDirLights,
+                                                                        .image = shadowMaps.directionalShadowMap,
                                                                     },
                                                                 },
                                                                 RgImageBinding{
@@ -966,7 +966,7 @@ namespace clove {
                                                                     .imageView = {
                                                                         .image      = shadowMaps.pointShadowMap,
                                                                         .viewType   = GhaImageView::Type::Cube,
-                                                                        .arrayCount = currentFrameData.numPointLights * cubeMapLayerCount,
+                                                                        .arrayCount = currentFrameData.numPointLights * static_cast<uint32_t>(cubeMapLayerCount),
                                                                     },
                                                                 },
                                                             },

--- a/clove/source/Rendering/HighDefinitionRenderer.cpp
+++ b/clove/source/Rendering/HighDefinitionRenderer.cpp
@@ -849,9 +849,18 @@ namespace clove {
     void HighDefinitionRenderer::renderSene(RenderGraph &renderGraph, std::vector<RenderGraphMeshInfo> const &meshes, ViewUniformBufferData const &viewUniformBuffer, LightGrid const &lightGrid, LightBuffers const &lightBuffers, RenderGraphShadowMaps const shadowMaps, RgImageId const renderTarget, RgImageId const depthTarget) {
         size_t const minUboOffsetAlignment{ ghaDevice->getLimits().minUniformBufferOffsetAlignment };
 
-        RgSampler shadowMapSampler{ renderGraph.createSampler(GhaSampler::Descriptor{
+        RgSampler const shadowMapSampler{ renderGraph.createSampler(GhaSampler::Descriptor{
             .minFilter        = GhaSampler::Filter::Linear,
             .magFilter        = GhaSampler::Filter::Linear,
+            .addressModeU     = GhaSampler::AddressMode::ClampToBorder,
+            .addressModeV     = GhaSampler::AddressMode::ClampToBorder,
+            .addressModeW     = GhaSampler::AddressMode::ClampToBorder,
+            .enableAnisotropy = false,
+        }) };
+
+        RgSampler const lightGridSampler{ renderGraph.createSampler(GhaSampler::Descriptor{
+            .minFilter        = GhaSampler::Filter::Nearest,
+            .magFilter        = GhaSampler::Filter::Nearest,
             .addressModeU     = GhaSampler::AddressMode::ClampToBorder,
             .addressModeV     = GhaSampler::AddressMode::ClampToBorder,
             .addressModeW     = GhaSampler::AddressMode::ClampToBorder,
@@ -1005,6 +1014,10 @@ namespace clove {
                                                                 RgSamplerBinding{
                                                                     .slot    = 9,//NOLINT
                                                                     .sampler = shadowMapSampler,
+                                                                },
+                                                                RgSamplerBinding{
+                                                                    .slot    = 15,//NOLINT
+                                                                    .sampler = lightGridSampler,
                                                                 },
                                                             },
                                                             .indexCount = mesh.indexCount,

--- a/clove/source/Rendering/HighDefinitionRenderer.cpp
+++ b/clove/source/Rendering/HighDefinitionRenderer.cpp
@@ -941,6 +941,12 @@ namespace clove {
                                                                     .size        = lightBuffers.lightsSize,
                                                                     .shaderStage = GhaShader::Stage::Pixel,
                                                                 },
+                                                                RgBufferBinding{
+                                                                    .slot        = 14,//NOLINT
+                                                                    .buffer      = lightGrid.lightIndexList,
+                                                                    .size        = lightGrid.lightIndexListSize,
+                                                                    .shaderStage = GhaShader::Stage::Pixel,
+                                                                },
                                                             },
                                                             .images = {
                                                                 RgImageBinding{
@@ -967,6 +973,12 @@ namespace clove {
                                                                         .image      = shadowMaps.pointShadowMap,
                                                                         .viewType   = GhaImageView::Type::Cube,
                                                                         .arrayCount = currentFrameData.numPointLights * static_cast<uint32_t>(cubeMapLayerCount),
+                                                                    },
+                                                                },
+                                                                RgImageBinding{
+                                                                    .slot      = 13,//NOLINT
+                                                                    .imageView = {
+                                                                        .image = lightGrid.lightGrid,
                                                                     },
                                                                 },
                                                             },

--- a/clove/source/Rendering/HighDefinitionRenderer.cpp
+++ b/clove/source/Rendering/HighDefinitionRenderer.cpp
@@ -548,6 +548,15 @@ namespace clove {
     }
 
     HighDefinitionRenderer::LightGrid HighDefinitionRenderer::computeLightGrid(RenderGraph &renderGraph, LightBuffers const &lightBuffers, RgImageId const sceneDepth) {
+        RgSampler const sceneDepthSampler{ renderGraph.createSampler(GhaSampler::Descriptor{
+            .minFilter        = GhaSampler::Filter::Nearest,
+            .magFilter        = GhaSampler::Filter::Nearest,
+            .addressModeU     = GhaSampler::AddressMode::ClampToBorder,
+            .addressModeV     = GhaSampler::AddressMode::ClampToBorder,
+            .addressModeW     = GhaSampler::AddressMode::ClampToBorder,
+            .enableAnisotropy = false,
+        }) };
+
         size_t constexpr gridSize{ 16 };         //How many threads are in the X and Y of a grid
         size_t constexpr maxLightsPerTile{ 256 };//Current total of how many lights a single tile will deal with.
 
@@ -626,6 +635,12 @@ namespace clove {
                                                                     .imageView = RgImageView{
                                                                         .image = lightGrid,
                                                                     },
+                                                                },
+                                                            },
+                                                            .samplers = {
+                                                                RgSamplerBinding{
+                                                                    .slot    = 5,//NOLINT
+                                                                    .sampler = sceneDepthSampler,
                                                                 },
                                                             },
                                                             .disptachSize = vec3ui{ lightGridSize.x, lightGridSize.y, 1 },

--- a/clove/source/Rendering/HighDefinitionRenderer.cpp
+++ b/clove/source/Rendering/HighDefinitionRenderer.cpp
@@ -639,7 +639,7 @@ namespace clove {
                                                             },
                                                             .samplers = {
                                                                 RgSamplerBinding{
-                                                                    .slot    = 5,//NOLINT
+                                                                    .slot    = 7,//NOLINT
                                                                     .sampler = sceneDepthSampler,
                                                                 },
                                                             },

--- a/clove/source/Rendering/RenderGraph/RgComputePass.cpp
+++ b/clove/source/Rendering/RenderGraph/RgComputePass.cpp
@@ -20,6 +20,9 @@ namespace clove {
             for(auto const &binding : submission.readStorageBuffers) {
                 inputs.emplace(binding.buffer);
             }
+            for(auto const &binding : submission.readImages) {
+                inputs.emplace(binding.imageView.image);
+            }
         }
         return inputs;
     }
@@ -29,6 +32,9 @@ namespace clove {
         for(auto const &submission : submissions) {
             for(auto const &binding : submission.writeBuffers) {
                 outputs.emplace(binding.buffer);
+            }
+            for(auto const &binding : submission.writeImages) {
+                outputs.emplace(binding.imageView.image);
             }
         }
         return outputs;

--- a/clove/source/Rendering/RenderGraph/RgRenderPass.cpp
+++ b/clove/source/Rendering/RenderGraph/RgRenderPass.cpp
@@ -24,6 +24,9 @@ namespace clove {
             for(auto const &image : submission.shaderImages) {
                 inputResources.emplace(image.imageView.image);
             }
+            if(descriptor.depthStencil.imageView.image != INVALID_RESOURCE_ID && descriptor.depthStencil.loadOp == LoadOperation::Load) {
+                inputResources.emplace(descriptor.depthStencil.imageView.image);
+            }
         }
         return inputResources;
     }
@@ -36,6 +39,10 @@ namespace clove {
         if(descriptor.depthStencil.imageView.image != INVALID_RESOURCE_ID) {
             outputResources.emplace(descriptor.depthStencil.imageView.image);
         }
+        if(descriptor.depthStencil.imageView.image != INVALID_RESOURCE_ID && descriptor.depthStencil.storeOp == StoreOperation::Store) {
+            outputResources.emplace(descriptor.depthStencil.imageView.image);
+        }
+
         return outputResources;
     }
 }

--- a/clove/source/Rendering/RenderGraph/RgRenderPass.cpp
+++ b/clove/source/Rendering/RenderGraph/RgRenderPass.cpp
@@ -18,10 +18,13 @@ namespace clove {
         for(auto const &submission : submissions) {
             inputResources.emplace(submission.vertexBuffer);
             inputResources.emplace(submission.indexBuffer);
-            for(auto const &ubo : submission.shaderUbos) {
+            for(auto const &ubo : submission.readUniformBuffers) {
                 inputResources.emplace(ubo.buffer);
             }
-            for(auto const &image : submission.shaderImages) {
+            for(auto const &sbo : submission.readStorageBuffers) {
+                inputResources.emplace(sbo.buffer);
+            }
+            for(auto const &image : submission.images) {
                 inputResources.emplace(image.imageView.image);
             }
             if(descriptor.depthStencil.imageView.image != INVALID_RESOURCE_ID && descriptor.depthStencil.loadOp == LoadOperation::Load) {

--- a/clove/source/Shaders/Common.glsl
+++ b/clove/source/Shaders/Common.glsl
@@ -1,0 +1,21 @@
+struct Light {
+    vec3 direction;
+    int shadowIndex;
+
+	vec3 position;
+	float constant;
+
+	vec3 ambient;
+	float linearV;
+
+	vec3 diffuse;
+	float quadratic;
+
+	vec3 specular;
+	float radius;
+
+    int type;
+    float padding_1;
+    float padding_2;
+    float padding_3;
+};

--- a/clove/source/Shaders/ComputeLightGridCompute.glsl
+++ b/clove/source/Shaders/ComputeLightGridCompute.glsl
@@ -22,8 +22,6 @@ layout(std140, set = 0, binding = 4) uniform FrustumData{
 	mat4 inverseProjection;
 };
 
-layout(set = 0, binding = 5) uniform sampler sceneDepthSampler;
-
 //TODO: push constant
 layout(std140, set = 0, binding = 5) uniform NumLights{
 	uint numLights;
@@ -32,6 +30,8 @@ layout(std140, set = 0, binding = 5) uniform NumLights{
 layout(std140, set = 0, binding = 6) buffer readonly Lights{
 	Light lights[];
 };
+
+layout(set = 0, binding = 7) uniform sampler sceneDepthSampler;
 
 shared uint minDepth;
 shared uint maxDepth;

--- a/clove/source/Shaders/ComputeLightGridCompute.glsl
+++ b/clove/source/Shaders/ComputeLightGridCompute.glsl
@@ -1,0 +1,166 @@
+#version 450
+
+#include "Constants.glsl"
+#include "Common.glsl"
+
+#define MAX_LIGHTS 1024
+#define MAX_LIGHTS_PER_TILE 256
+#define GROUP_SIZE 16
+
+layout(set = 0, binding = 0) uniform writeonly image2D lightGrid;
+layout(set = 0, binding = 1, r32f) uniform readonly image2D sceneDepth;
+
+layout(std140, set = 0, binding = 2) buffer CulledLights{
+	uint lightIndexList[];
+};
+
+layout(std140, set = 0, binding = 3) buffer LightCounter{
+	uint lightCounter;
+};
+
+layout(std140, set = 0, binding = 4) uniform FrustumData{
+	vec2 screenDimensions;
+	mat4 inverseProjection;
+};
+
+//TODO: push constant
+layout(std140, set = 0, binding = 5) uniform NumLights{
+	uint numLights;
+};
+
+layout(std140, set = 0, binding = 6) buffer readonly Lights{
+	Light lights[];
+};
+
+shared uint minDepth;
+shared uint maxDepth;
+
+shared uint lightCount;
+shared uint lightIndexStartOffset;
+shared uint lightList[MAX_LIGHTS_PER_TILE];
+
+layout(local_size_x = GROUP_SIZE) in;
+layout(local_size_y = GROUP_SIZE) in;
+
+struct Plane {
+	vec3 normal;
+	float dist;
+};
+
+struct Frustum {
+	Plane planes[6];
+};
+
+Plane computePlane(vec3 p0, vec3 p1, vec3 p2) {
+	Plane plane;
+
+	const vec3 v0 = p1 - p0;
+	const vec3 v1 = p2 - p0;
+
+	plane.normal = normalize(cross(v0, v1));
+	plane.dist	 = dot(plane.normal, p0);
+
+	return plane;
+}
+
+vec4 clipToView(vec4 clip) {
+	vec4 view = inverseProjection *clip;
+    view = view / view.w;
+
+    return view;
+}
+
+vec4 screenToView(vec4 screen) {
+    const vec2 texCoord = screen.xy / screenDimensions;
+    const vec4 clip = vec4(vec2(texCoord.x, 1.0f - texCoord.y) * 2.0f - 1.0f, screen.z, screen.w);
+
+    return clipToView(clip);
+}
+
+bool isLightInsideFrustum(Light light, Frustum frustum) {
+	switch(light.type) {
+		case LIGHT_TYPE_DIRECTIONAL:
+			return true; //Directional lights will always pass as they take up the entire view
+		case LIGHT_TYPE_POINT: {
+			bool isInside = true;
+			for(int i = 0; i < 6 && isInside; ++i){
+				const Plane plane = frustum.planes[i];
+				isInside = dot(plane.normal, light.position) - plane.dist < -light.radius;
+			}
+			return isInside;
+		}
+	}
+}
+
+void main(){
+	const ivec2 pixelPos = ivec2(gl_GlobalInvocationID.xy);
+
+	if(gl_LocalInvocationIndex == 0) {
+		minDepth = 0xFFFFFFFF;
+		maxDepth = 0;
+
+		lightCount = 0;
+	}
+
+	groupMemoryBarrier();
+
+	{
+		const uint depth = floatBitsToUint(imageLoad(sceneDepth, pixelPos).r);
+
+		atomicMin(minDepth, depth);
+		atomicMax(maxDepth, depth);
+	}
+	
+	groupMemoryBarrier();
+
+	//Compute frustum - TODO: Only needs to be calculated if screen changes size (min and max will always need to be calculated)
+    Frustum frustum;
+	{
+		const vec3 eyePos = vec3(0.0f);
+
+		vec4 screenSpace[4];
+    	screenSpace[0] = vec4(pixelPos.xy * GROUP_SIZE, -1.0f, 1.0f); 								
+    	screenSpace[1] = vec4(vec2(pixelPos.x + 1, 	pixelPos.y) 		* GROUP_SIZE, -1.0f, 1.0f); 
+    	screenSpace[2] = vec4(vec2(pixelPos.x, 		pixelPos.y + 1) 	* GROUP_SIZE, -1.0f, 1.0f); 
+    	screenSpace[3] = vec4(vec2(pixelPos.x + 1, 	pixelPos.y + 1) 	* GROUP_SIZE, -1.0f, 1.0f); 
+
+		vec3 viewSpace[4];
+		for(int i = 0; i < 4; ++i){
+			viewSpace[i] = screenToView(screenSpace[i]).xyz;
+		}
+
+		const float minDepthVs = clipToView(vec4(0.0f, 0.0f, uintBitsToFloat(minDepth), 1.0f)).z;
+		const float maxDepthVs = clipToView(vec4(0.0f, 0.0f, uintBitsToFloat(maxDepth), 1.0f)).z;
+
+    	frustum.planes[0] = computePlane(eyePos, viewSpace[2], viewSpace[0]); 	//Top left
+    	frustum.planes[1] = computePlane(eyePos, viewSpace[1], viewSpace[3]); 	//Top right
+    	frustum.planes[2] = computePlane(eyePos, viewSpace[0], viewSpace[1]); 	//Bottom left
+    	frustum.planes[3] = computePlane(eyePos, viewSpace[3], viewSpace[2]); 	//Bottom right
+		frustum.planes[4] = Plane(vec3(0.0f, 0.0f, -1.0f), -minDepthVs); 		//Near
+		frustum.planes[5] = Plane(vec3(0.0f, 0.0f,  1.0f),  maxDepthVs);		//Far
+	}
+
+	groupMemoryBarrier();
+
+	//Cull point lights against frustum
+	for(uint lightIndex = gl_LocalInvocationIndex; lightIndex < numLights; lightIndex += GROUP_SIZE * GROUP_SIZE) {
+		if(isLightInsideFrustum(lights[lightIndex], frustum)){
+			const uint index = atomicAdd(lightCount, 1);
+			lightList[index] = lightIndex;
+		}
+	}
+
+	groupMemoryBarrier();
+
+	//Write culled lights into the grid / light list
+	if(gl_LocalInvocationIndex == 0){
+		lightIndexStartOffset = atomicAdd(lightCounter, lightCount);
+		imageStore(lightGrid, ivec2(gl_WorkGroupID.xy), uvec4(lightIndexStartOffset, lightCount, 0, 0));
+	}
+
+	groupMemoryBarrier();
+
+	for(uint lightIndex = gl_LocalInvocationIndex; lightIndex < lightCount; lightIndex += GROUP_SIZE * GROUP_SIZE) {
+		lightIndexList[lightIndexStartOffset + lightIndex] = lightList[lightIndex];
+	}	
+}

--- a/clove/source/Shaders/ComputeLightGridCompute.glsl
+++ b/clove/source/Shaders/ComputeLightGridCompute.glsl
@@ -7,7 +7,7 @@
 #define GROUP_SIZE 16
 
 layout(set = 0, binding = 0) uniform writeonly uimage2D lightGrid;
-layout(set = 0, binding = 1, r32f) uniform readonly image2D sceneDepth;
+layout(set = 0, binding = 1) uniform texture2D sceneDepth;
 
 layout(std140, set = 0, binding = 2) buffer CulledLights{
 	uint lightIndexList[];
@@ -21,6 +21,8 @@ layout(std140, set = 0, binding = 4) uniform FrustumData{
 	vec2 screenDimensions;
 	mat4 inverseProjection;
 };
+
+layout(set = 0, binding = 5) uniform sampler sceneDepthSampler;
 
 //TODO: push constant
 layout(std140, set = 0, binding = 5) uniform NumLights{
@@ -104,7 +106,7 @@ void main(){
 	groupMemoryBarrier();
 
 	{
-		const uint depth = floatBitsToUint(imageLoad(sceneDepth, pixelPos).r);
+		const uint depth = floatBitsToUint(texelFetch(sampler2D(sceneDepth, sceneDepthSampler), pixelPos, 0).r);
 
 		atomicMin(minDepth, depth);
 		atomicMax(maxDepth, depth);

--- a/clove/source/Shaders/ComputeLightGridCompute.glsl
+++ b/clove/source/Shaders/ComputeLightGridCompute.glsl
@@ -3,11 +3,10 @@
 #include "Constants.glsl"
 #include "Common.glsl"
 
-#define MAX_LIGHTS 1024
 #define MAX_LIGHTS_PER_TILE 256
 #define GROUP_SIZE 16
 
-layout(set = 0, binding = 0) uniform writeonly image2D lightGrid;
+layout(set = 0, binding = 0) uniform writeonly uimage2D lightGrid;
 layout(set = 0, binding = 1, r32f) uniform readonly image2D sceneDepth;
 
 layout(std140, set = 0, binding = 2) buffer CulledLights{

--- a/clove/source/Shaders/Constants.glsl
+++ b/clove/source/Shaders/Constants.glsl
@@ -1,5 +1,8 @@
-#define MAX_LIGHTS 10
+#define MAX_LIGHTS 1024
 #define MAX_JOINTS 255 //std::numeric_limits<JointIndexType>::max();
+
+#define LIGHT_TYPE_DIRECTIONAL 0
+#define LIGHT_TYPE_POINT 1
 
 //Descriptor Sets
 #define SET_MESH 0

--- a/clove/source/Shaders/ForwardPassPixel.glsl
+++ b/clove/source/Shaders/ForwardPassPixel.glsl
@@ -17,7 +17,8 @@ layout(set = 0, binding = 10) uniform ViewPosition{
 	vec3 viewPos;
 };
 
-layout(set = 0, binding = 13, rg32ui) uniform readonly uimage2D lightGrid;
+layout(set = 0, binding = 13) uniform utexture2D lightGrid;
+layout(set = 0, binding = 15) uniform sampler lightGridSampler;
 
 layout(std140, set = 0, binding = 14) buffer readonly CulledLights{
 	uint lightIndexList[];
@@ -144,7 +145,7 @@ void main(){
 	float shadow = 0.0f;
 
 	const ivec2 tileIndex 	= ivec2(floor(gl_FragCoord / SCREEN_GRID_SIZE));
-	const uvec2 tileData	= imageLoad(lightGrid, tileIndex).xy;
+	const uvec2 tileData	= texelFetch(usampler2D(lightGrid, lightGridSampler), tileIndex, 0).xy;
 	const uint startOffset 	= tileData.x;
 	const uint lightCount 	= tileData.y;
 

--- a/clove/source/Shaders/ForwardPassPixel.glsl
+++ b/clove/source/Shaders/ForwardPassPixel.glsl
@@ -1,6 +1,9 @@
 #version 450
 
+#include "Common.glsl"
 #include "Constants.glsl"
+
+#define SCREEN_GRID_SIZE 16
 
 layout(set = 0, binding = 4) uniform texture2D diffuseTexture;
 layout(set = 0, binding = 5) uniform texture2D specularTexture;
@@ -14,32 +17,14 @@ layout(set = 0, binding = 10) uniform ViewPosition{
 	vec3 viewPos;
 };
 
-struct DirectionalLightData{
-	vec3 direction;
+layout(set = 0, binding = 13, rg32ui) uniform readonly uimage2D lightGrid;
 
-	vec3 ambient;
-	vec3 diffuse;
-	vec3 specular;
+layout(std140, set = 0, binding = 14) buffer readonly CulledLights{
+	uint lightIndexList[];
 };
-struct PointLightData{
-	vec3 position;
-	
-	float constant;
-	vec3 ambient;
-	float linearV;
-	vec3 diffuse;
-	float quadratic;
-	vec3 specular;
-	
-	float farplane;
-};
-layout(std140, set = 0, binding = 11) uniform Lights{
-	DirectionalLightData directionalLights[MAX_LIGHTS];
-	PointLightData pointLights[MAX_LIGHTS];
-};
-layout(std140, set = 0, binding = 2) uniform NumLights{
-	uint numDirLights;
-	uint numPointLights;
+
+layout(std140, set = 0, binding = 11) buffer readonly Lights{
+	Light lights[];
 };
 
 layout(std140, set = 0, binding = 12) uniform Colour{
@@ -50,98 +35,134 @@ layout(location = 0) in vec3 fragColour;
 layout(location = 1) in vec2 fragTexCoord;
 layout(location = 2) in vec3 fragPos;
 layout(location = 3) in vec3 fragNorm;
-layout(location = 4) in vec4 fragPosLightSpaces[MAX_LIGHTS];
+layout(location = 4) in vec4 fragPosLightSpaces;
 
 layout(location = 0) out vec4 outColour;
+
+struct LightingInput{
+	Light light;
+
+	vec3 diffuseColour;
+	vec3 specularColour;
+
+	float shininess;
+
+	vec3 viewDir;
+	vec3 normal;
+};
 
 //Adjusts the bias to be in between min and max based off of the angle to the light
 float adjustBias(float minBias, float maxBias, vec3 normal, vec3 lightDir){
 	return max(maxBias * (1.0f - dot(normal, lightDir)), minBias);
 }
 
-void main(){
-	const vec3 diffuseColour = texture(sampler2D(diffuseTexture, meshSampler), fragTexCoord).rgb;
-	const vec3 specularColour = texture(sampler2D(specularTexture, meshSampler), fragTexCoord).rgb;
-
-	vec3 viewDir = normalize(viewPos - fragPos);
-
-	vec3 normal = normalize(fragNorm);
-
-	vec3 totalAmbient = vec3(0);
-	vec3 totalDiffuse = vec3(0);
-	vec3 totalSpecular = vec3(0);
-
-	const float shiniess =  32.0f; //TODO: Add shiniess as a material param
-
+void getDirectionalLighting(LightingInput lightingInput, inout vec3 outAmbient, inout vec3 outDiffuse, inout vec3 outSpecular, inout float outShadow){
 	const float minBias = 0.0005f;
 	const float maxBias = 0.025f;
 
+	const Light light = lightingInput.light;
+
+	const vec3 lightDir = normalize(-light.direction); //Gets the direction towards the light
+		
+	//Ambient
+	outAmbient += lightingInput.diffuseColour * light.ambient;
+	
+	//Diffuse
+	const float diffIntensity = max(dot(lightingInput.normal, lightDir), 0.0f);
+	outDiffuse += lightingInput.diffuseColour * light.diffuse * diffIntensity;
+
+	//Specular
+	const vec3 reflectDir = reflect(-lightDir, lightingInput.normal);
+	const float specIntensity = pow(max(dot(lightingInput.viewDir, reflectDir), 0.0f), lightingInput.shininess);
+	outSpecular += lightingInput.specularColour * light.specular * specIntensity;
+
+	//Shadow
+	vec3 projCoords = fragPosLightSpaces[light.shadowIndex].xyz / fragPosLightSpaces[light.shadowIndex].w;
+	projCoords.xy = projCoords.xy * 0.5f + 0.5f;
+
+	const float currentDepth = projCoords.z;
+	const float closetDepth  = texture(sampler2DArray(directionalDepthTexture, shadowSampler), vec3(projCoords.xy, light.shadowIndex)).r;
+
+	outShadow += currentDepth - adjustBias(minBias, maxBias, lightingInput.normal, lightDir) > closetDepth ? 1.0f : 0.0f;
+}
+
+void getPointLighting(LightingInput lightingInput, inout vec3 outAmbient, inout vec3 outDiffuse, inout vec3 outSpecular, in out float outShadow){
+	const float minBias = 0.0005f;
+	const float maxBias = 0.025f;
+
+	const Light light = lightingInput.light;
+
+	const vec3 lightDir = normalize(light.position - fragPos);
+
+	//Ambient
+	vec3 ambient = lightingInput.diffuseColour * light.ambient;
+
+	//Diffuse
+	const float diffIntensity = max(dot(lightingInput.normal, lightDir), 0.0f);
+	vec3 diffuse = lightingInput.diffuseColour * light.diffuse * diffIntensity;
+
+	//Specular
+	const vec3 reflectDir = reflect(-lightDir, lightingInput.normal);
+	const float specIntensity = pow(max(dot(lightingInput.viewDir, reflectDir), 0.0f), lightingInput.shininess);
+	vec3 specular = lightingInput.specularColour * light.specular * specIntensity;
+
+	//Attenuation
+	const float dist 		= length(light.position - fragPos);
+	const float attenuation = 1.0f / (light.constant + (light.linearV * dist) + (light.quadratic * (dist * dist)));
+
+	ambient		*= attenuation;
+	diffuse		*= attenuation;
+	specular	*= attenuation;
+
+	outAmbient += ambient;
+	outDiffuse += diffuse;
+	outSpecular += specular;
+
+	//Shadow
+	const vec3 lightToFrag = fragPos - light.position;
+
+	const float currentDepth = length(lightToFrag);
+	const float closetDepth  = texture(samplerCubeArray(pointLightDepthTexture, shadowSampler), vec4(lightToFrag, light.shadowIndex)).r * light.radius;
+
+	outShadow += currentDepth - adjustBias(minBias, maxBias, lightingInput.normal, lightDir) > closetDepth ? 1.0f : 0.0f;
+}
+
+void main(){
+	LightingInput lightingInput;
+	lightingInput.diffuseColour 	= texture(sampler2D(diffuseTexture, meshSampler), fragTexCoord).rgb;
+	lightingInput.specularColour 	= texture(sampler2D(specularTexture, meshSampler), fragTexCoord).rgb;
+	
+	lightingInput.shininess = 32.0f; //TODO: Add shininess as a material param
+
+	lightingInput.viewDir = normalize(viewPos - fragPos);
+	lightingInput.normal = normalize(fragNorm);
+
+	vec3 totalAmbient 	= vec3(0.0f);
+	vec3 totalDiffuse 	= vec3(0.0f);
+	vec3 totalSpecular 	= vec3(0.0f);
+
 	float shadow = 0.0f;
 
-	//Directional lighting
-	for(int i = 0; i < numDirLights; ++i){
-		const vec3 lightDir = normalize(-directionalLights[i].direction); //Gets the direction towards the light
-		
-		//Ambient
-		totalAmbient += diffuseColour * directionalLights[i].ambient;
-	
-		//Diffuse
-		const float diffIntensity = max(dot(normal, lightDir), 0.0f);
-		totalDiffuse += diffuseColour * directionalLights[i].diffuse * diffIntensity;
+	const ivec2 tileIndex 	= ivec2(floor(gl_FragCoord / SCREEN_GRID_SIZE));
+	const uvec2 tileData	= imageLoad(lightGrid, tileIndex).xy;
+	const uint startOffset 	= tileData.x;
+	const uint lightCount 	= tileData.y;
 
-		//Specular
-		const vec3 reflectDir = reflect(-lightDir, normal);
-		const float specIntensity = pow(max(dot(viewDir, reflectDir), 0.0f), shiniess);
-		totalSpecular += specularColour * directionalLights[i].specular * specIntensity;
+	//Compute lighting
+	for(int i = 0; i < lightCount; ++i) {
+		lightingInput.light = lights[startOffset + i];
 
-		//Shadow
-		vec3 projCoords = fragPosLightSpaces[i].xyz / fragPosLightSpaces[i].w;
-		projCoords.xy = projCoords.xy * 0.5f + 0.5f;
-
-		const float currentDepth = projCoords.z;
-		const float closetDepth = texture(sampler2DArray(directionalDepthTexture, shadowSampler), vec3(projCoords.xy, i)).r;
-
-		shadow += currentDepth - adjustBias(minBias, maxBias, normal, lightDir) > closetDepth ? 1.0f : 0.0f;
+		switch(lightingInput.light.type) {
+			case LIGHT_TYPE_DIRECTIONAL:
+				getDirectionalLighting(lightingInput, totalAmbient, totalDiffuse, totalSpecular, shadow);
+				break;
+			case LIGHT_TYPE_POINT:
+				getPointLighting(lightingInput, totalAmbient, totalDiffuse, totalSpecular, shadow);
+				break;
+		}
 	}
 
-	//Point lighting
-	for(int i = 0; i < numPointLights; ++i){
-		const vec3 lightDir = normalize(pointLights[i].position - fragPos);
-
-		//Ambient
-		vec3 ambient = diffuseColour * pointLights[i].ambient;
-
-		//Diffuse
-		const float diffIntensity = max(dot(normal, lightDir), 0.0f);
-		vec3 diffuse = diffuseColour * pointLights[i].diffuse * diffIntensity;
-
-		//Specular
-		const vec3 reflectDir = reflect(-lightDir, normal);
-		const float specIntensity = pow(max(dot(viewDir, reflectDir), 0.0f), shiniess);
-		vec3 specular = specularColour * pointLights[i].specular * specIntensity;
-
-		//Attenuation
-		float dist = length(pointLights[i].position - fragPos);
-		float attenuation = 1.0f / (pointLights[i].constant + (pointLights[i].linearV * dist) + (pointLights[i].quadratic * (dist * dist)));
-
-		ambient		*= attenuation;
-		diffuse		*= attenuation;
-		specular	*= attenuation;
-
-		totalAmbient += ambient;
-		totalDiffuse += diffuse;
-		totalSpecular += specular;
-
-		//Shadow
-		const vec3 lightToFrag = fragPos - pointLights[i].position;
-
-		const float currentDepth = length(lightToFrag);
-		const float closetDepth = texture(samplerCubeArray(pointLightDepthTexture, shadowSampler), vec4(lightToFrag, i)).r * pointLights[i].farplane;
-
-		shadow += currentDepth - adjustBias(minBias, maxBias, normal, lightDir) > closetDepth ? 1.0f : 0.0f;
-	}
-
-	shadow /= (numDirLights + numPointLights);
+	shadow /= (lightCount);
 
 	const vec3 lighting = (totalAmbient + ((1.0f - shadow) * (totalDiffuse + totalSpecular)));
 

--- a/clove/source/Shaders/ForwardPassPixel.glsl
+++ b/clove/source/Shaders/ForwardPassPixel.glsl
@@ -9,7 +9,7 @@ layout(set = 0, binding = 4) uniform texture2D diffuseTexture;
 layout(set = 0, binding = 5) uniform texture2D specularTexture;
 layout(set = 0, binding = 6) uniform sampler meshSampler;
 
-layout(set = 0, binding = 7) uniform texture2DArray directionalDepthTexture;
+layout(set = 0, binding = 7) uniform texture2D directionalDepthTexture;
 layout(set = 0, binding = 8) uniform textureCubeArray pointLightDepthTexture;
 layout(Set = 0, binding = 9) uniform sampler shadowSampler;
 
@@ -77,11 +77,11 @@ void getDirectionalLighting(LightingInput lightingInput, inout vec3 outAmbient, 
 	outSpecular += lightingInput.specularColour * light.specular * specIntensity;
 
 	//Shadow
-	vec3 projCoords = fragPosLightSpaces[light.shadowIndex].xyz / fragPosLightSpaces[light.shadowIndex].w;
+	vec3 projCoords = fragPosLightSpaces.xyz / fragPosLightSpaces.w;
 	projCoords.xy = projCoords.xy * 0.5f + 0.5f;
 
 	const float currentDepth = projCoords.z;
-	const float closetDepth  = texture(sampler2DArray(directionalDepthTexture, shadowSampler), vec3(projCoords.xy, light.shadowIndex)).r;
+	const float closetDepth  = texture(sampler2D(directionalDepthTexture, shadowSampler), projCoords.xy).r;
 
 	outShadow += currentDepth - adjustBias(minBias, maxBias, lightingInput.normal, lightDir) > closetDepth ? 1.0f : 0.0f;
 }

--- a/clove/source/Shaders/ForwardPassVert.glsl
+++ b/clove/source/Shaders/ForwardPassVert.glsl
@@ -18,7 +18,7 @@ layout(std140, set = 0, binding = 2) uniform NumLights{
 };
 
 layout(std140, set = 0, binding = 3) uniform LightMatrix{
-	mat4 lightSpaceMatrices[];
+	mat4 directionalLightSpaceMatrix;
 };
 
 layout(location = 0) in vec3 position;
@@ -41,7 +41,5 @@ void main(){
 	vertPos = vec3(model * vec4(position, 1.0f));
 	vertNorm = mat3(normalMatrix) * normal;
 
-	for(int i = 0; i < numDirLights; ++i){
-		vertPosLightSpaces[i] = lightSpaceMatrices[i] * vec4(vertPos, 1.0f);
-	}
+	vertPosLightSpaces = directionalLightSpaceMatrix * vec4(vertPos, 1.0f);
 }

--- a/clove/source/Shaders/ForwardPassVert.glsl
+++ b/clove/source/Shaders/ForwardPassVert.glsl
@@ -12,12 +12,13 @@ layout(std140, set = 0, binding = 1) uniform ViewProj{
 	mat4 proj;
 };
 
+//TODO: Push constant
 layout(std140, set = 0, binding = 2) uniform NumLights{
 	int numDirLights;
-	int numPointLights;
 };
+
 layout(std140, set = 0, binding = 3) uniform LightMatrix{
-	mat4 lightSpaceMatrices[MAX_LIGHTS];
+	mat4 lightSpaceMatrices[];
 };
 
 layout(location = 0) in vec3 position;
@@ -29,7 +30,7 @@ layout(location = 0) out vec3 fragColour;
 layout(location = 1) out vec2 fragTexCoord;
 layout(location = 2) out vec3 vertPos;
 layout(location = 3) out vec3 vertNorm;
-layout(location = 4) out vec4 vertPosLightSpaces[MAX_LIGHTS];
+layout(location = 4) out vec4 vertPosLightSpaces;
 
 void main(){
 	gl_Position = proj * view * model * vec4(position, 1.0f);

--- a/clove/source/Shaders/SceneDepthPixel.glsl
+++ b/clove/source/Shaders/SceneDepthPixel.glsl
@@ -1,0 +1,5 @@
+#version 450
+
+void main(){
+    gl_FragDepth = gl_FragCoord.z;
+}

--- a/clove/source/Shaders/SceneDepthVert.glsl
+++ b/clove/source/Shaders/SceneDepthVert.glsl
@@ -1,0 +1,19 @@
+#version 450
+
+#include "Constants.glsl"
+
+layout(std140, set = 0, binding = 0) uniform Model{
+	mat4 model;
+	mat4 normalMatrix;
+};
+
+layout(std140, set = 0, binding = 1) uniform ViewProj{
+	mat4 view;
+	mat4 proj;
+};
+
+layout(location = 0) in vec3 position;
+
+void main(){
+    gl_Position = proj * view * model * vec4(position, 1.0f);
+}

--- a/clove/source/SubSystems/RenderSubSystem.cpp
+++ b/clove/source/SubSystems/RenderSubSystem.cpp
@@ -7,8 +7,8 @@
 #include "Clove/Components/PointLightComponent.hpp"
 #include "Clove/Components/StaticModelComponent.hpp"
 #include "Clove/Components/TransformComponent.hpp"
-#include "Clove/Rendering/Renderer.hpp"
 #include "Clove/Rendering/Renderables/Mesh.hpp"
+#include "Clove/Rendering/Renderer.hpp"
 
 #include <Clove/ECS/EntityManager.hpp>
 #include <Clove/Maths/Maths.hpp>
@@ -55,7 +55,7 @@ namespace clove {
         entityManager->forEach([this](TransformComponent const &transform, StaticModelComponent const &staticModel) {
             if(staticModel.model.isValid()) {
                 mat4f const modelTransform{ transform.worldMatrix };
-                
+
                 for(auto const &mesh : staticModel.model->getMeshes()) {
                     renderer->submitMesh(Renderer::MeshInfo{ mesh, staticModel.material, modelTransform });
                 }
@@ -81,7 +81,7 @@ namespace clove {
             float constexpr farDist{ 100.0f };
             mat4f const shadowProj{ createOrthographicMatrix(-mapSize, mapSize, -mapSize, mapSize, nearDist, farDist) };
 
-            DirectionalLight lightProxy{
+            Renderer::DirectionalLight lightProxy{
                 .data = {
                     .direction = light.direction,
                     .ambient   = light.ambientColour,
@@ -100,13 +100,13 @@ namespace clove {
 
             vec3f const &position{ transform.position };
 
-            PointLight lightProxy{
+            Renderer::PointLight lightProxy{
                 .data = {
                     .position = position,
                     .ambient  = light.ambientColour,
                     .diffuse  = light.diffuseColour,
                     .specular = light.specularColour,
-                    .farPlane = farDist,
+                    .radius   = farDist,
                 },
                 .shadowTransforms = {
                     shadowProj * lookAt(position, position + vec3f{ 1.0f, 0.0f, 0.0f }, vec3f{ 0.0f, 1.0f, 0.0f }),


### PR DESCRIPTION
## Summary
Clove's forward+ renderer

Closes #438 

## Changes
- Refactored Clove's renderer to use a Forward+ system.
- Added storage image support to the GHA.
- Added storage support to the render graph.
- Fixed render graph execution order when using depth targets as inputs.
- Added R32G32_UINT image format to the GHA.
- Removed support for multiple directional lights.