### PR TITLE
Refactor/loading globals

### DIFF
--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -38,6 +38,7 @@ typedef void (*OnModuleLoadedFn)();
 typedef void (*OnModuleRemovedFn)();
 
 typedef void (*LinkApplicationFn)(clove::Application *app);
+typedef void (*LinkLoggerFn)(clove::Logger *logger);
 typedef void (*LinkReflectionFn)(clove::reflection::internal::Registry *reg);
 
 namespace {
@@ -212,6 +213,13 @@ namespace membrane {
                     LinkApplicationFn proc{ (LinkApplicationFn)GetProcAddress(gameLibrary, "linkApplication") };
                     CLOVE_ASSERT(proc);
                     proc(&clove::Application::get());
+                }
+
+                //Set up module's logger
+                {
+                    LinkLoggerFn proc{ (LinkLoggerFn)GetProcAddress(gameLibrary, "linkLogger") };
+                    CLOVE_ASSERT(proc);
+                    proc(&clove::Logger::get());
                 }
 
                 //Set up module's reflection system

--- a/clove/components/systems/reflection/source/Reflection.cpp
+++ b/clove/components/systems/reflection/source/Reflection.cpp
@@ -8,7 +8,7 @@ static clove::reflection::internal::Registry *instance{ nullptr };
 
 #if CLOVE_PLATFORM_WINDOWS
 extern "C" {
-__declspec(dllexport) void setUpReflector(clove::reflection::internal::Registry *reg) {
+__declspec(dllexport) void linkReflection(clove::reflection::internal::Registry *reg) {
     std::unordered_map<clove::reflection::TypeId, clove::reflection::TypeInfo> types{ clove::reflection::internal::Registry::get().getRegisteredTypes() };
 
     for(auto &&[id, info] : types) {

--- a/clove/components/utilities/log/include/Clove/Log/Log.hpp
+++ b/clove/components/utilities/log/include/Clove/Log/Log.hpp
@@ -34,7 +34,7 @@ namespace clove {
         Logger();
         ~Logger();
 
-        static inline Logger &get();
+        static Logger &get();
 
         template<typename... Args>
         void log(std::string_view category, LogLevel level, std::string_view msg, Args &&...args);

--- a/clove/components/utilities/log/include/Clove/Log/Log.inl
+++ b/clove/components/utilities/log/include/Clove/Log/Log.inl
@@ -1,16 +1,6 @@
 #include <fmt/format.h>
 
 namespace clove {
-    Logger &Logger::get(){
-        static Logger *instance{ nullptr };
-
-        if(instance == nullptr){
-            instance = new Logger;
-        }
-
-        return *instance;
-    }
-
     template<typename... Args>
     void Logger::log(std::string_view category, LogLevel level, std::string_view msg, Args &&... args) {
         fmt::basic_memory_buffer<char, 250> messageBuffer{};

--- a/clove/components/utilities/log/source/Log.cpp
+++ b/clove/components/utilities/log/source/Log.cpp
@@ -6,6 +6,19 @@
 #include <spdlog/spdlog.h>
 #include <vector>
 
+static clove::Logger *instance{ nullptr };
+
+#if CLOVE_PLATFORM_WINDOWS
+extern "C" {
+__declspec(dllexport) void linkLogger(clove::Logger *logger) {
+    if(instance != nullptr) {
+        delete instance;
+    }
+    instance = logger;
+}
+}
+#endif
+
 namespace clove {
     Logger::Logger() {
         auto consoleSink{ std::make_shared<spdlog::sinks::stdout_color_sink_mt>() };
@@ -23,6 +36,14 @@ namespace clove {
     }
 
     Logger::~Logger() = default;
+
+    Logger &Logger::get() {
+        if(instance == nullptr) {
+            instance = new Logger{};
+        }
+
+        return *instance;
+    }
 
     void Logger::addSink(std::shared_ptr<spdlog::sinks::sink> sink) {
         logger->sinks().push_back(std::move(sink));

--- a/clove/include/Clove/Application.hpp
+++ b/clove/include/Clove/Application.hpp
@@ -37,7 +37,6 @@ namespace clove {
 
         //VARIABLES
     private:
-        static Application *instance;
         State currentState{ State::Running };//Assumed to be initialised to the running state.
 
         std::unique_ptr<GhaDevice> graphicsDevice;
@@ -89,12 +88,6 @@ namespace clove {
          * @return A pair with the created application instance and a pointer to the render target of the application.
          */
         static std::pair<std::unique_ptr<Application>, GraphicsImageRenderTarget *> createHeadless(GraphicsApi graphicsApi, AudioApi audioApi, GhaImage::Descriptor renderTargetDescriptor, Keyboard *keyboard, Mouse *mouse);
-
-        /**
-         * @brief Set the static application instance with an existing one.
-         * @param app 
-         */
-        static void set(Application *app);
 
         static Application &get();
 

--- a/clove/source/Application.cpp
+++ b/clove/source/Application.cpp
@@ -14,9 +14,20 @@
 #include <Clove/Graphics/Gha.hpp>
 #include <Clove/Graphics/GhaDevice.hpp>
 
-namespace clove {
-    Application *Application::instance{ nullptr };
+clove::Application *instance{ nullptr };
 
+#if CLOVE_PLATFORM_WINDOWS
+extern "C" {
+__declspec(dllexport) void linkApplication(clove::Application *app) {
+    if(instance != nullptr){
+        delete instance;
+    }
+    instance = app;
+}
+}
+#endif
+
+namespace clove {
     Application::~Application() {
         //Tell all subSystems they have been detached when the application is shutdown
         for(auto &&[key, group] : subSystems) {
@@ -56,10 +67,6 @@ namespace clove {
         std::unique_ptr<Application> app{ new Application{ std::move(graphicsDevice), std::move(audioDevice), keyboard, mouse, std::move(renderTarget) } };
 
         return { std::move(app), renderTargetPtr };
-    }
-
-    void Application::set(Application *app) {
-        instance = app;
     }
 
     Application &Application::get() {


### PR DESCRIPTION
## Changes
- `clove::Application` now gets linked to the editor's instance when loading the game module.
- `Logger` now gets linked to the editor's instance when loading the game module.