### PR TITLE
Remove the ability to record once and replay buffers

### DIFF
--- a/clove/components/core/graphics/CMakeLists.txt
+++ b/clove/components/core/graphics/CMakeLists.txt
@@ -189,7 +189,6 @@ set(
 #Library
 add_library(
 	CloveGraphics STATIC
-		${INCLUDE}/CommandBuffer.hpp
 		${INCLUDE}/Descriptor.hpp
 		${INCLUDE}/Gha.hpp		
 		${SOURCE}/Gha.cpp

--- a/clove/components/core/graphics/CMakeLists.txt
+++ b/clove/components/core/graphics/CMakeLists.txt
@@ -30,6 +30,7 @@ set(
 		${INCLUDE}/Vulkan/VulkanCommandBuffer.hpp
 		${SOURCE}/Vulkan/VulkanCommandBuffer.cpp
 		${INCLUDE}/Vulkan/VulkanComputeCommandBuffer.hpp
+		${INCLUDE}/Vulkan/VulkanComputeCommandBuffer.inl
 		${SOURCE}/Vulkan/VulkanComputeCommandBuffer.cpp
 		${INCLUDE}/Vulkan/VulkanComputePipelineObject.hpp
 		${SOURCE}/Vulkan/VulkanComputePipelineObject.cpp
@@ -52,6 +53,7 @@ set(
 		${INCLUDE}/Vulkan/VulkanGha.hpp
 		${SOURCE}/Vulkan/VulkanGha.cpp
 		${INCLUDE}/Vulkan/VulkanGraphicsCommandBuffer.hpp
+		${INCLUDE}/Vulkan/VulkanGraphicsCommandBuffer.inl
 		${SOURCE}/Vulkan/VulkanGraphicsCommandBuffer.cpp
 		${INCLUDE}/Vulkan/VulkanGraphicsPipelineObject.hpp
 		${SOURCE}/Vulkan/VulkanGraphicsPipelineObject.cpp
@@ -90,6 +92,7 @@ set(
 		${INCLUDE}/Vulkan/VulkanSwapchain.hpp
 		${SOURCE}/Vulkan/VulkanSwapchain.cpp
 		${INCLUDE}/Vulkan/VulkanTransferCommandBuffer.hpp
+		${INCLUDE}/Vulkan/VulkanTransferCommandBuffer.inl
 		${SOURCE}/Vulkan/VulkanTransferCommandBuffer.cpp
 		${INCLUDE}/Vulkan/VulkanTransferQueue.hpp
 		${SOURCE}/Vulkan/VulkanTransferQueue.cpp

--- a/clove/components/core/graphics/include/Clove/Graphics/CommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/CommandBuffer.hpp
@@ -1,8 +1,0 @@
-#pragma once
-
-namespace clove {
-    enum class CommandBufferUsage {
-        Default,       /**< Command buffer will be recorded and used mutliple times before re-recording. */
-        OneTimeSubmit, /**< Command buffer will be recorded and used only once before re-recording. */
-    };
-}

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaComputeCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaComputeCommandBuffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Clove/Graphics/CommandBuffer.hpp"
 #include "Clove/Graphics/GhaShader.hpp"
 #include "Clove/Graphics/MemoryBarrier.hpp"
 #include "Clove/Graphics/PipelineObject.hpp"
@@ -24,17 +23,16 @@ namespace clove {
     public:
         virtual ~GhaComputeCommandBuffer() = default;
 
+        virtual void beginRecording() = 0;
         /**
-         * @brief Begin recording commands on the buffer. This will implicitly reset the buffer.
-         * @param usageFlag 
+         * @brief End recording on this command buffer. Command buffers cannot be resued after recording has finished.
          */
-        virtual void beginRecording(CommandBufferUsage usageFlag) = 0;
-        virtual void endRecording()                               = 0;
+        virtual void endRecording()   = 0;
 
         virtual void bindPipelineObject(GhaComputePipelineObject &pipelineObject) = 0;
 
         virtual void bindDescriptorSet(GhaDescriptorSet &descriptorSet, uint32_t const setNum) = 0;
-        virtual void pushConstant(size_t const offset, size_t const size, void const *data) = 0;
+        virtual void pushConstant(size_t const offset, size_t const size, void const *data)    = 0;
 
         virtual void disptach(vec3ui groupCount) = 0;
 

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaGraphicsCommandBuffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Clove/Graphics/CommandBuffer.hpp"
 #include "Clove/Graphics/GhaShader.hpp"
 #include "Clove/Graphics/MemoryBarrier.hpp"
 #include "Clove/Graphics/PipelineObject.hpp"
@@ -49,12 +48,11 @@ namespace clove {
     public:
         virtual ~GhaGraphicsCommandBuffer() = default;
 
+        virtual void beginRecording() = 0;
         /**
-         * @brief Begin recording commands on the buffer. This will implicitly reset the buffer.
-         * @param usageFlag 
+         * @brief End recording on this command buffer. Command buffers cannot be resued after recording has finished.
          */
-        virtual void beginRecording(CommandBufferUsage usageFlag) = 0;
-        virtual void endRecording()                               = 0;
+        virtual void endRecording()   = 0;
 
         /**
          * @details Begins a GhaRenderPass. All subsiquent calls will use this render pass.

--- a/clove/components/core/graphics/include/Clove/Graphics/GhaTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/GhaTransferCommandBuffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Clove/Graphics/CommandBuffer.hpp"
 #include "Clove/Graphics/GhaImage.hpp"
 #include "Clove/Graphics/MemoryBarrier.hpp"
 #include "Clove/Graphics/PipelineObject.hpp"
@@ -21,12 +20,11 @@ namespace clove {
     public:
         virtual ~GhaTransferCommandBuffer() = default;
 
+        virtual void beginRecording() = 0;
         /**
-         * @brief Begin recording commands on the buffer. This will implicitly reset the buffer.
-         * @param usageFlag 
+         * @brief End recording on this command buffer. Command buffers cannot be resued after recording has finished.
          */
-        virtual void beginRecording(CommandBufferUsage usageFlag) = 0;
-        virtual void endRecording()                               = 0;
+        virtual void endRecording()   = 0;
 
         /**
          * @brief Copy the contents from one buffer to another.

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeCommandBuffer.hpp
@@ -14,13 +14,15 @@ namespace clove {
 	class MetalComputeCommandBuffer : public GhaComputeCommandBuffer {
 		//VARIABLES
 	private:
-		std::vector<std::function<void(id<MTLComputeCommandEncoder>)>> commands{};
-        
+        id<MTLCommandBuffer> commandBuffer{ nullptr };
+        id<MTLComputeCommandEncoder> encoder{ nullptr };
+
         MetalComputePipelineObject *activePipeline{ nullptr }; //Required to get shader workgroup size
 			
 		//FUNCTIONS
 	public:
-        MetalComputeCommandBuffer();
+        MetalComputeCommandBuffer() = delete;
+        MetalComputeCommandBuffer(id<MTLCommandBuffer> commandBuffer);
 
         MetalComputeCommandBuffer(MetalComputeCommandBuffer const &other) = delete;
 		MetalComputeCommandBuffer(MetalComputeCommandBuffer &&other) noexcept;
@@ -30,7 +32,7 @@ namespace clove {
 		
 		~MetalComputeCommandBuffer();
 
-		void beginRecording(CommandBufferUsage usageFlag) override;
+		void beginRecording() override;
         void endRecording() override;
 
 		void bindPipelineObject(GhaComputePipelineObject &pipelineObject) override;
@@ -42,9 +44,10 @@ namespace clove {
 
 		void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 		void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
-		
-		inline std::vector<std::function<void(id<MTLComputeCommandEncoder>)>> const &getCommands() const;
-	};
+
+        inline id<MTLCommandBuffer> getMtlCommandBuffer() const;
+        inline id<MTLComputeCommandEncoder> getEncoder() const;
+    };
 }
 
 #include "MetalComputeCommandBuffer.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalComputeCommandBuffer.inl
@@ -1,5 +1,9 @@
 namespace clove {
-	std::vector<std::function<void(id<MTLComputeCommandEncoder>)>> const &MetalComputeCommandBuffer::getCommands() const {
-		return commands;
-	}
+    id<MTLCommandBuffer> MetalComputeCommandBuffer::getMtlCommandBuffer() const {
+        return commandBuffer;
+    }
+
+    id<MTLComputeCommandEncoder> MetalComputeCommandBuffer::getEncoder() const {
+        return encoder;
+    }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsCommandBuffer.hpp
@@ -8,13 +8,6 @@
 
 namespace clove {
 	class MetalGraphicsCommandBuffer : public GhaGraphicsCommandBuffer {
-		//TYPES
-	public:
-		struct RenderPass {
-			std::function<id<MTLRenderCommandEncoder>(id<MTLCommandBuffer>)> begin{};
-			std::vector<std::function<void(id<MTLRenderCommandEncoder>)>> commands{};
-		};
-		
 	private:
 		struct CachedIndexBufferData {
 			id<MTLBuffer> buffer{};
@@ -24,15 +17,18 @@ namespace clove {
 		
 		//VARIABLES
 	private:
-		std::vector<RenderPass> passes{};
-		RenderPass *currentPass{ nullptr };
-		
-		//Metal's drawIndexed call takes an index buffer directly so we need to cache the one provided from bindIndexBuffer
+        id<MTLCommandBuffer> commandBuffer{ nullptr };
+        id<MTLRenderCommandEncoder> currentPass{ nullptr };
+
+        std::vector<id<MTLRenderCommandEncoder>> passes{};
+
+        //Metal's drawIndexed call takes an index buffer directly so we need to cache the one provided from bindIndexBuffer
 		CachedIndexBufferData cachedIndexBuffer;
 		
 		//FUNCTIONS
 	public:
-        MetalGraphicsCommandBuffer();
+        MetalGraphicsCommandBuffer() = delete;
+        MetalGraphicsCommandBuffer(id<MTLCommandBuffer> commandBuffer);
 
         MetalGraphicsCommandBuffer(MetalGraphicsCommandBuffer const &other) = delete;
 		MetalGraphicsCommandBuffer(MetalGraphicsCommandBuffer &&other) noexcept;
@@ -42,7 +38,7 @@ namespace clove {
 		
 		~MetalGraphicsCommandBuffer();
 		
-		void beginRecording(CommandBufferUsage usageFlag) override;
+		void beginRecording() override;
 		void endRecording() override;
 
 		void beginRenderPass(GhaRenderPass &renderPass, GhaFramebuffer &frameBuffer, RenderArea const &renderArea, std::span<ClearValue> clearValues) override;
@@ -62,9 +58,10 @@ namespace clove {
 
 		void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 		void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
-		
-		inline std::vector<RenderPass> const &getEncodedRenderPasses() const;
-	};
+
+        inline id<MTLCommandBuffer> getMtlCommandBuffer() const;
+        inline std::vector<id<MTLRenderCommandEncoder>> const &getRenderPasses() const;
+    };
 }
 
 #include "Clove/Graphics/Metal/MetalGraphicsCommandBuffer.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalGraphicsCommandBuffer.inl
@@ -1,5 +1,9 @@
 namespace clove {
-	std::vector<MetalGraphicsCommandBuffer::RenderPass> const &MetalGraphicsCommandBuffer::getEncodedRenderPasses() const {
-		return passes;
-	}
+    id<MTLCommandBuffer> MetalGraphicsCommandBuffer::getMtlCommandBuffer() const {
+        return commandBuffer;
+    }
+
+    std::vector<id<MTLRenderCommandEncoder>> const &MetalGraphicsCommandBuffer::getRenderPasses() const {
+        return passes;
+    }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferCommandBuffer.hpp
@@ -10,13 +10,15 @@ namespace clove {
 	class MetalTransferCommandBuffer : public GhaTransferCommandBuffer {
 		//VARIABLES
 	private:
-		std::vector<std::function<void(id<MTLBlitCommandEncoder>)>> commands{};
-			
+        id<MTLCommandBuffer> commandBuffer{ nullptr };
+        id<MTLBlitCommandEncoder> encoder{ nullptr };
+
 		//FUNCTIONS
-	public:
-        MetalTransferCommandBuffer();
-		
-		MetalTransferCommandBuffer(MetalTransferCommandBuffer const &other) = delete;
+    public: 
+		MetalTransferCommandBuffer() = default;
+        MetalTransferCommandBuffer(id<MTLCommandBuffer> commandBuffer);
+
+        MetalTransferCommandBuffer(MetalTransferCommandBuffer const &other) = delete;
 		MetalTransferCommandBuffer(MetalTransferCommandBuffer &&other) noexcept;
 		
 		MetalTransferCommandBuffer &operator=(MetalTransferCommandBuffer const &other) = delete;
@@ -24,7 +26,7 @@ namespace clove {
 		
 		~MetalTransferCommandBuffer();
 
-		void beginRecording(CommandBufferUsage usageFlag) override;
+		void beginRecording() override;
 		void endRecording() override;
 
 		void copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes) override;
@@ -34,9 +36,10 @@ namespace clove {
 
         void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 		void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
-		
-		inline std::vector<std::function<void(id<MTLBlitCommandEncoder>)>> const &getCommands() const;
-	};
+
+        inline id<MTLCommandBuffer> getMtlCommandBuffer() const;
+        inline id<MTLBlitCommandEncoder> getEncoder() const;
+    };
 }
 
 #include "MetalTransferCommandBuffer.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Metal/MetalTransferCommandBuffer.inl
@@ -1,5 +1,9 @@
 namespace clove {
-	std::vector<std::function<void(id<MTLBlitCommandEncoder>)>> const &MetalTransferCommandBuffer::getCommands() const {
-		return commands;
-	}
+    id<MTLCommandBuffer> MetalTransferCommandBuffer::getMtlCommandBuffer() const {
+        return commandBuffer;
+    }
+
+    id<MTLBlitCommandEncoder> MetalTransferCommandBuffer::getEncoder() const {
+        return encoder;
+    }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationCommandBuffer.hpp
@@ -8,24 +8,17 @@ namespace clove {
     class ValidationCommandBuffer {
         //VARIABLES
     private:
-        CommandBufferUsage currentUsage{ CommandBufferUsage::Default };
-        bool allowReuse{ false };  /**< Will be true if this can be reused (recorded to multiple times without beeing freed) */
         bool hasBeenUsed{ false }; /**< Will be true if this buffer has been used before being rerecorded. */
         bool endRecordingCalled{ true };
 
         //FUNCTIONS
     public:
-        void setAllowBufferReuse(bool canReuse);
         void markAsUsed();
         bool bufferHasBeenUsed() const;
-
-        CommandBufferUsage getCommandBufferUsage() const;
 
     protected:
         void validateBeginRecording();
         void resetUsedFlag();
-
-        void setCommandBufferUsage(CommandBufferUsage usage);
 
         void onEndRecording();
     };
@@ -36,7 +29,7 @@ namespace clove {
     public:
         using BaseCommandBufferType::BaseCommandBufferType;
 
-        void beginRecording(CommandBufferUsage usageFlag) override;
+        void beginRecording() override;
         void endRecording() override;
     };
 
@@ -46,7 +39,7 @@ namespace clove {
     public:
         using BaseCommandBufferType::BaseCommandBufferType;
 
-        void beginRecording(CommandBufferUsage usageFlag) override;
+        void beginRecording() override;
         void endRecording() override;
     };
 
@@ -56,7 +49,7 @@ namespace clove {
     public:
         using BaseCommandBufferType::BaseCommandBufferType;
 
-        void beginRecording(CommandBufferUsage usageFlag) override;
+        void beginRecording() override;
         void endRecording() override;
     };
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationCommandBuffer.inl
@@ -2,55 +2,43 @@
 namespace clove {
     //Graphics
     template<typename BaseCommandBufferType>
-    void ValidationGraphicsCommandBuffer<BaseCommandBufferType>::beginRecording(CommandBufferUsage usageFlag) {
+    void ValidationGraphicsCommandBuffer<BaseCommandBufferType>::beginRecording() {
         validateBeginRecording();
-
-        setCommandBufferUsage(usageFlag);
         resetUsedFlag();
-
-        BaseCommandBufferType::beginRecording(usageFlag);
+        BaseCommandBufferType::beginRecording();
     }
 
     template<typename BaseCommandBufferType>
     void ValidationGraphicsCommandBuffer<BaseCommandBufferType>::endRecording() {
         onEndRecording();
-
         BaseCommandBufferType::endRecording();
     }
 
     //Compute
     template<typename BaseCommandBufferType>
-    void ValidationComputeCommandBuffer<BaseCommandBufferType>::beginRecording(CommandBufferUsage usageFlag) {
+    void ValidationComputeCommandBuffer<BaseCommandBufferType>::beginRecording() {
         validateBeginRecording();
-
-        setCommandBufferUsage(usageFlag);
         resetUsedFlag();
-
-        BaseCommandBufferType::beginRecording(usageFlag);
+        BaseCommandBufferType::beginRecording();
     }
 
     template<typename BaseCommandBufferType>
     void ValidationComputeCommandBuffer<BaseCommandBufferType>::endRecording() {
         onEndRecording();
-
         BaseCommandBufferType::endRecording();
     }
 
     //Transfer
     template<typename BaseCommandBufferType>
-    void ValidationTransferCommandBuffer<BaseCommandBufferType>::beginRecording(CommandBufferUsage usageFlag) {
+    void ValidationTransferCommandBuffer<BaseCommandBufferType>::beginRecording() {
         validateBeginRecording();
-
-        setCommandBufferUsage(usageFlag);
         resetUsedFlag();
-
-        BaseCommandBufferType::beginRecording(usageFlag);
+        BaseCommandBufferType::beginRecording();
     }
 
     template<typename BaseCommandBufferType>
     void ValidationTransferCommandBuffer<BaseCommandBufferType>::endRecording() {
         onEndRecording();
-
         BaseCommandBufferType::endRecording();
     }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.hpp
@@ -11,8 +11,6 @@ namespace clove {
     public:
         using BaseQueueType::BaseQueueType;
 
-        std::unique_ptr<GhaGraphicsCommandBuffer> allocateCommandBuffer() override;
-
         void submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 
@@ -22,8 +20,6 @@ namespace clove {
     public:
         using BaseQueueType::BaseQueueType;
 
-        std::unique_ptr<GhaComputeCommandBuffer> allocateCommandBuffer() override;
-
         void submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) override;
     };
 
@@ -32,8 +28,6 @@ namespace clove {
         //FUNCTIONS
     public:
         using BaseQueueType::BaseQueueType;
-
-        std::unique_ptr<GhaTransferCommandBuffer> allocateCommandBuffer() override;
 
         void submit(TransferSubmitInfo const &submission, GhaFence *signalFence) override;
     };

--- a/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Validation/ValidationQueue.inl
@@ -1,21 +1,12 @@
 #include "Clove/Graphics/Validation/ValidationCommandBuffer.hpp"
 
 namespace clove {
-    namespace detail {
-        template<typename QueueType, typename BufferType>
-        void initialiseBuffer(QueueType *queue, BufferType *buffer) {
-            bool const allowBufferReuse{ (queue->getDescriptor().flags & QueueFlags::ReuseBuffers) != 0 };
-            dynamic_cast<ValidationCommandBuffer *>(buffer)->setAllowBufferReuse(allowBufferReuse);
-        }
-
+    namespace internal {
         template<typename SubmissionType>
         void validateBuffersUsage(SubmissionType const &submission) {
             for(auto &commandBuffer : submission.commandBuffers) {
                 auto *buffer{ dynamic_cast<ValidationCommandBuffer *>(commandBuffer) };
-                if(buffer->getCommandBufferUsage() == CommandBufferUsage::OneTimeSubmit && buffer->bufferHasBeenUsed()) {
-                    CLOVE_ASSERT_MSG(false, "GraphicsCommandBuffer recorded with CommandBufferUsage::OneTimeSubmit has already been used. Only buffers recorded with CommandBufferUsage::Default can submitted multiples times after being recorded once.");
-                    break;
-                }
+                CLOVE_ASSERT_MSG(!buffer->bufferHasBeenUsed(), "Command buffer has already been used.");
             }
         }
 
@@ -29,58 +20,25 @@ namespace clove {
 
     //Graphics
     template<typename BaseQueueType>
-    std::unique_ptr<GhaGraphicsCommandBuffer> ValidationGraphicsQueue<BaseQueueType>::allocateCommandBuffer() {
-        auto commandBuffer{ BaseQueueType::allocateCommandBuffer() };
-
-        detail::initialiseBuffer(this, commandBuffer.get());
-
-        return commandBuffer;
-    }
-
-    template<typename BaseQueueType>
     void ValidationGraphicsQueue<BaseQueueType>::submit(GraphicsSubmitInfo const &submission, GhaFence *signalFence) {
-        detail::validateBuffersUsage(submission);
-
+        internal::validateBuffersUsage(submission);
         BaseQueueType::submit(submission, signalFence);
-
-        detail::markBuffersAsUsed(submission);
+        internal::markBuffersAsUsed(submission);
     }
 
     //Compute
     template<typename BaseQueueType>
-    std::unique_ptr<GhaComputeCommandBuffer> ValidationComputeQueue<BaseQueueType>::allocateCommandBuffer() {
-        auto commandBuffer{ BaseQueueType::allocateCommandBuffer() };
-
-        detail::initialiseBuffer(this, commandBuffer.get());
-
-        return commandBuffer;
-    }
-
-    template<typename BaseQueueType>
     void ValidationComputeQueue<BaseQueueType>::submit(ComputeSubmitInfo const &submission, GhaFence *signalFence) {
-        detail::validateBuffersUsage(submission);
-
+        internal::validateBuffersUsage(submission);
         BaseQueueType::submit(submission, signalFence);
-
-        detail::markBuffersAsUsed(submission);
+        internal::markBuffersAsUsed(submission);
     }
 
     //Transfer
     template<typename BaseQueueType>
-    std::unique_ptr<GhaTransferCommandBuffer> ValidationTransferQueue<BaseQueueType>::allocateCommandBuffer() {
-        auto commandBuffer{ BaseQueueType::allocateCommandBuffer() };
-
-        detail::initialiseBuffer(this, commandBuffer.get());
-
-        return commandBuffer;
-    }
-
-    template<typename BaseQueueType>
     void ValidationTransferQueue<BaseQueueType>::submit(TransferSubmitInfo const &submission, GhaFence *signalFence) {
-        detail::validateBuffersUsage(submission);
-
+        internal::validateBuffersUsage(submission);
         BaseQueueType::submit(submission, signalFence);
-
-        detail::markBuffersAsUsed(submission);
+        internal::markBuffersAsUsed(submission);
     }
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanCommandBuffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Clove/Graphics/CommandBuffer.hpp"
 #include "Clove/Graphics/Vulkan/VulkanMemoryBarrier.hpp"
 #include "Clove/Graphics/Vulkan/VulkanPipelineObject.hpp"
 #include "Clove/Graphics/Vulkan/VulkanTypes.hpp"
@@ -12,8 +11,6 @@ namespace clove {
 }
 
 namespace clove {
-    VkCommandBufferUsageFlags getCommandBufferUsageFlags(CommandBufferUsage garlicUsage);
-
     void createBufferMemoryBarrier(VkCommandBuffer vkCommandBuffer, QueueFamilyIndices const &queueFamilyIndices, GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage);
     void createImageMemoryBarrier(VkCommandBuffer vkCommandBuffer, QueueFamilyIndices const &queueFamilyIndices, GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage);
 }

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeCommandBuffer.hpp
@@ -55,6 +55,8 @@ namespace clove {
          */
         void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 
-        VkCommandBuffer getCommandBuffer() const;
+        inline VkCommandBuffer getCommandBuffer() const;
     };
 }
+
+#include "VulkanComputeCommandBuffer.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeCommandBuffer.hpp
@@ -28,7 +28,7 @@ namespace clove {
 
         ~VulkanComputeCommandBuffer();
 
-        void beginRecording(CommandBufferUsage usageFlag) override;
+        void beginRecording() override;
         void endRecording() override;
 
         void bindPipelineObject(GhaComputePipelineObject &pipelineObject) override;

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanComputeCommandBuffer.inl
@@ -1,0 +1,5 @@
+namespace clove {
+    VkCommandBuffer VulkanComputeCommandBuffer::getCommandBuffer() const {
+        return commandBuffer;
+    }
+}

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.hpp
@@ -28,7 +28,7 @@ namespace clove {
 
         ~VulkanGraphicsCommandBuffer();
 
-        void beginRecording(CommandBufferUsage usageFlag) override;
+        void beginRecording() override;
         void endRecording() override;
 
         void beginRenderPass(GhaRenderPass &renderPass, GhaFramebuffer &frameBuffer, RenderArea const &renderArea, std::span<ClearValue> clearValues) override;

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.hpp
@@ -49,6 +49,8 @@ namespace clove {
         void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
         void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 
-        VkCommandBuffer getCommandBuffer() const;
+        inline VkCommandBuffer getCommandBuffer() const;
     };
 }
+
+#include "VulkanGraphicsCommandBuffer.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanGraphicsCommandBuffer.inl
@@ -1,0 +1,5 @@
+namespace clove {
+    VkCommandBuffer VulkanGraphicsCommandBuffer::getCommandBuffer() const {
+        return commandBuffer;
+    }
+}

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp
@@ -9,7 +9,7 @@ namespace clove {
     class VulkanTransferCommandBuffer : public GhaTransferCommandBuffer {
         //VARIABLES
     private:
-        VkCommandBuffer commandBuffer = VK_NULL_HANDLE;
+        VkCommandBuffer commandBuffer{ VK_NULL_HANDLE };
 
         QueueFamilyIndices queueFamilyIndices;
 
@@ -37,6 +37,8 @@ namespace clove {
         void bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
         void imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) override;
 
-        VkCommandBuffer getCommandBuffer() const;
+        inline VkCommandBuffer getCommandBuffer() const;
     };
 }
+
+#include "VulkanTransferCommandBuffer.inl"

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.hpp
@@ -26,7 +26,7 @@ namespace clove {
 
         ~VulkanTransferCommandBuffer();
 
-        void beginRecording(CommandBufferUsage usageFlag) override;
+        void beginRecording() override;
         void endRecording() override;
 
         void copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes) override;

--- a/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.inl
+++ b/clove/components/core/graphics/include/Clove/Graphics/Vulkan/VulkanTransferCommandBuffer.inl
@@ -1,0 +1,5 @@
+namespace clove {
+    VkCommandBuffer VulkanTransferCommandBuffer::getCommandBuffer() const {
+        return commandBuffer;
+    }
+}

--- a/clove/components/core/graphics/source/Metal/MetalComputeCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalComputeCommandBuffer.mm
@@ -11,7 +11,9 @@
 #include <Clove/Cast.hpp>
 
 namespace clove {
-	MetalComputeCommandBuffer::MetalComputeCommandBuffer() = default;
+	MetalComputeCommandBuffer::MetalComputeCommandBuffer(id<MTLCommandBuffer> commandBuffer) 
+		: commandBuffer{ commandBuffer } {
+	}
 	
 	MetalComputeCommandBuffer::MetalComputeCommandBuffer(MetalComputeCommandBuffer &&other) noexcept = default;
 	
@@ -19,8 +21,8 @@ namespace clove {
 	
 	MetalComputeCommandBuffer::~MetalComputeCommandBuffer() = default;
 
-	void MetalComputeCommandBuffer::beginRecording(CommandBufferUsage usageFlag) {
-		commands.clear();
+	void MetalComputeCommandBuffer::beginRecording() {
+        encoder = [commandBuffer computeCommandEncoder];
 	}
 	
 	void MetalComputeCommandBuffer::endRecording() {
@@ -31,94 +33,50 @@ namespace clove {
         auto *const metalPipelineObject{ polyCast<MetalComputePipelineObject>(&pipelineObject) };
         activePipeline = metalPipelineObject;
         
-		commands.emplace_back([metalPipelineObject](id<MTLComputeCommandEncoder> encoder) {
-			[encoder setComputePipelineState:metalPipelineObject->getPipelineState()];
-		});
+		[encoder setComputePipelineState:metalPipelineObject->getPipelineState()];
 	}
 
 	void MetalComputeCommandBuffer::bindDescriptorSet(GhaDescriptorSet &descriptorSet, uint32_t const setNum) {
-		commands.emplace_back([descriptorSet = &descriptorSet, setNum](id<MTLComputeCommandEncoder> encoder) {
-            auto const *const metalDescriptorSet{ polyCast<MetalDescriptorSet>(descriptorSet) };
-            if(metalDescriptorSet == nullptr) {
-                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: DescriptorSet is nullptr", CLOVE_FUNCTION_NAME);
-                return;
-            }
-            
-            id<MTLBuffer> backingBuffer{ metalDescriptorSet->getBackingBuffer() };
-            std::optional<size_t> computeOffset{ metalDescriptorSet->getComputeOffset() };
-            CLOVE_ASSERT(computeOffset.has_value());
-            
-            [encoder setBuffer:backingBuffer
-                        offset:computeOffset.value()
-                       atIndex:setNum];
-		});
+		auto const *const metalDescriptorSet{ polyCast<MetalDescriptorSet>(&descriptorSet) };
+        if(metalDescriptorSet == nullptr) {
+            CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: DescriptorSet is nullptr", CLOVE_FUNCTION_NAME);
+            return;
+        }
+        
+        id<MTLBuffer> backingBuffer{ metalDescriptorSet->getBackingBuffer() };
+        std::optional<size_t> computeOffset{ metalDescriptorSet->getComputeOffset() };
+        CLOVE_ASSERT(computeOffset.has_value());
+        
+        [encoder setBuffer:backingBuffer
+                    offset:computeOffset.value()
+                   atIndex:setNum];
 	}
 	
 	void MetalComputeCommandBuffer::pushConstant(size_t const offset, size_t const size, void const *data) {
-		class Functor{
-			//VARIABLES
-		private:
-			size_t size{};
-			std::unique_ptr<std::byte> data{};
-			
-			//FUNCTIONS
-		public:
-			Functor() = delete;
-			Functor(size_t size, void const *data)
-				: size{ size }
-				, data{ reinterpret_cast<std::byte*>(malloc(size)) } {
-				memcpy(this->data.get(), data, size);
-			}
-			
-			Functor(Functor const &other)
-				: size{ other.size } {
-				data = std::unique_ptr<std::byte>{ reinterpret_cast<std::byte*>(malloc(size)) };
-				memcpy(data.get(), other.data.get(), size);
-			}
-			Functor(Functor &&other) = default;
-			
-			Functor &operator=(Functor const &other) {
-				size = other.size;
-				data = std::unique_ptr<std::byte>{ reinterpret_cast<std::byte*>(malloc(size)) };
-				memcpy(data.get(), other.data.get(), size);
-			}
-			Functor &operator=(Functor &&other) = default;
-			
-			~Functor() = default;
-			
-			void operator()(id<MTLComputeCommandEncoder> encoder) {
-				[encoder setBytes:data.get()
-						   length:size
-						  atIndex:pushConstantSlot];
-			}
-		};
-		
-		commands.emplace_back(Functor{ size, data });
+		[encoder setBytes:data
+				   length:size
+				  atIndex:pushConstantSlot];
 	}
 
 	void MetalComputeCommandBuffer::disptach(vec3ui groupCount) {
         auto const *const metalShader{ polyCast<MetalShader const>(activePipeline->getDescriptor().shader) };
         vec3ui const workGroupSize{ metalShader != nullptr ? metalShader->getWorkgroupSize() : vec3ui{ 1, 1, 1 } };
         
-		commands.emplace_back([workGroupSize, groupCount](id<MTLComputeCommandEncoder> encoder){
-			[encoder dispatchThreadgroups:MTLSizeMake(groupCount.x, groupCount.y, groupCount.z)
-					threadsPerThreadgroup:MTLSizeMake(workGroupSize.x, workGroupSize.y, workGroupSize.z)];
-		});
+		[encoder dispatchThreadgroups:MTLSizeMake(groupCount.x, groupCount.y, groupCount.z)
+				threadsPerThreadgroup:MTLSizeMake(workGroupSize.x, workGroupSize.y, workGroupSize.z)];
 	}
 
 	void MetalComputeCommandBuffer::bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
-		commands.emplace_back([buffer = &buffer, sourceStage, destinationStage](id<MTLComputeCommandEncoder> encoder){
-			id<MTLBuffer> mtlBuffer{ polyCast<MetalBuffer>(buffer)->getBuffer() };
-			[encoder memoryBarrierWithResources:&mtlBuffer
-										  count:1];
-		});
+		id<MTLBuffer> mtlBuffer{ polyCast<MetalBuffer>(&buffer)->getBuffer() };
+
+		[encoder memoryBarrierWithResources:&mtlBuffer
+									  count:1];
 	}
 	
 	void MetalComputeCommandBuffer::imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
-		commands.emplace_back([image = &image, sourceStage, destinationStage](id<MTLComputeCommandEncoder> encoder){
-			id<MTLTexture> mtlTexture{ polyCast<MetalImage>(image)->getTexture() };
-			[encoder memoryBarrierWithResources:&mtlTexture
-										  count:1];
-		});
+		id<MTLTexture> mtlTexture{ polyCast<MetalImage>(&image)->getTexture() };
+
+		[encoder memoryBarrierWithResources:&mtlTexture
+									  count:1];
 	}
 }

--- a/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
+++ b/clove/components/core/graphics/source/Metal/MetalTransferCommandBuffer.mm
@@ -26,7 +26,9 @@ namespace clove {
 		}
 	}
 	
-	MetalTransferCommandBuffer::MetalTransferCommandBuffer() = default;
+	MetalTransferCommandBuffer::MetalTransferCommandBuffer(id<MTLCommandBuffer> commandBuffer) 
+		: commandBuffer{ commandBuffer } {
+	}
 	
 	MetalTransferCommandBuffer::MetalTransferCommandBuffer(MetalTransferCommandBuffer &&other) noexcept = default;
 	
@@ -34,75 +36,69 @@ namespace clove {
 	
 	MetalTransferCommandBuffer::~MetalTransferCommandBuffer() = default;
 
-	void MetalTransferCommandBuffer::beginRecording(CommandBufferUsage usageFlag) {
-		commands.clear();
+	void MetalTransferCommandBuffer::beginRecording() {
+		encoder = [commandBuffer blitCommandEncoder];
 	}
 	
 	void MetalTransferCommandBuffer::endRecording() {
-		//no op
+		//no op - endEncoding happens in the queue to allow semaphore insertion.
 	}
 
 	void MetalTransferCommandBuffer::copyBufferToBuffer(GhaBuffer &source, size_t const sourceOffset, GhaBuffer &destination, size_t const destinationOffset, size_t const sizeBytes) {
-		commands.emplace_back([source = &source, sourceOffset, destination = &destination, destinationOffset, sizeBytes](id<MTLBlitCommandEncoder> encoder){
-			[encoder copyFromBuffer:polyCast<MetalBuffer>(source)->getBuffer()
-					   sourceOffset:sourceOffset
-						   toBuffer:polyCast<MetalBuffer>(destination)->getBuffer()
-				  destinationOffset:destinationOffset
-							   size:sizeBytes];
-		});
+		[encoder copyFromBuffer:polyCast<MetalBuffer>(&source)->getBuffer()
+				   sourceOffset:sourceOffset
+					   toBuffer:polyCast<MetalBuffer>(&destination)->getBuffer()
+			  destinationOffset:destinationOffset
+						   size:sizeBytes];
 	}
 	
 	void MetalTransferCommandBuffer::copyBufferToImage(GhaBuffer &source, size_t const sourceOffset, GhaImage &destination, vec3i const &destinationOffset, vec3ui const &destinationExtent, uint32_t const destinationBaseLayer, uint32_t const destinationLayerCount) {
-		commands.emplace_back([source = &source, sourceOffset, destination = &destination, destinationOffset, destinationExtent, destinationBaseLayer, destinationLayerCount](id<MTLBlitCommandEncoder> encoder){
-			auto const *const metalImage{ polyCast<MetalImage>(destination) };
-            if(metalImage == nullptr){
-                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
-                return;
-            }
-            
-			auto const &imageDescriptor{ metalImage->getDescriptor() };
-			
-			[encoder copyFromBuffer:polyCast<MetalBuffer>(source)->getBuffer()
-					   sourceOffset:sourceOffset
-				  sourceBytesPerRow:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x //Always assume the bytes per row is the same as the image's width. Metal does not consider 0 tightly packed like Vulkan does
-				sourceBytesPerImage:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x * imageDescriptor.dimensions.y * destinationLayerCount
-						 sourceSize:MTLSizeMake(destinationExtent.x, destinationExtent.y, 1)
-						  toTexture:metalImage->getTexture()
-				   destinationSlice:destinationBaseLayer
-				   destinationLevel:0
-				  destinationOrigin:MTLOriginMake(destinationOffset.x, destinationOffset.y, 0)];
-		});
+		auto const *const metalImage{ polyCast<MetalImage>(&destination) };
+        if(metalImage == nullptr){
+            CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
+            return;
+        }
+        
+		auto const &imageDescriptor{ metalImage->getDescriptor() };
+		
+		[encoder copyFromBuffer:polyCast<MetalBuffer>(&source)->getBuffer()
+				   sourceOffset:sourceOffset
+			  sourceBytesPerRow:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x //Always assume the bytes per row is the same as the image's width. Metal does not consider 0 tightly packed like Vulkan does
+			sourceBytesPerImage:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x * imageDescriptor.dimensions.y * destinationLayerCount
+					 sourceSize:MTLSizeMake(destinationExtent.x, destinationExtent.y, 1)
+					  toTexture:metalImage->getTexture()
+			   destinationSlice:destinationBaseLayer
+			   destinationLevel:0
+			  destinationOrigin:MTLOriginMake(destinationOffset.x, destinationOffset.y, 0)];
 	}
 
 	void MetalTransferCommandBuffer::copyImageToBuffer(GhaImage &source, vec3i const &sourceOffset, vec3ui const &sourceExtent, uint32_t const sourceBaseLayer, uint32_t const sourceLayerCount, GhaBuffer &destination, size_t const destinationOffset) {
-		commands.emplace_back([source = &source, sourceOffset, sourceExtent, destination = &destination, destinationOffset, sourceBaseLayer, sourceLayerCount](id<MTLBlitCommandEncoder> encoder){
-			auto const *const metalImage{ polyCast<MetalImage>(source) };
-            if(metalImage == nullptr){
-                CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
-                return;
-            }
-            
-			auto const &imageDescriptor{ metalImage->getDescriptor() };
-			
-			[encoder copyFromTexture:metalImage->getTexture()
-						 sourceSlice:sourceBaseLayer
-						 sourceLevel:0
-						sourceOrigin:MTLOriginMake(sourceOffset.x, sourceOffset.y, 0)
-						  sourceSize:MTLSizeMake(sourceExtent.x, sourceExtent.y, 1)
-							toBuffer:polyCast<MetalBuffer>(destination)->getBuffer()
-				   destinationOffset:destinationOffset
-			  destinationBytesPerRow:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x //Always assume the bytes per row is the same as the image's width. Metal does not consider 0 tightly packed like Vulkan does
-			destinationBytesPerImage:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x * imageDescriptor.dimensions.y * sourceLayerCount];
-		});
+		auto const *const metalImage{ polyCast<MetalImage>(&source) };
+        if(metalImage == nullptr){
+           CLOVE_LOG(CloveGhaMetal, LogLevel::Error, "{0}: Source image is nullptr", CLOVE_FUNCTION_NAME);
+           return;
+        }
+           
+		auto const &imageDescriptor{ metalImage->getDescriptor() };
+		
+		[encoder copyFromTexture:metalImage->getTexture()
+					 sourceSlice:sourceBaseLayer
+					 sourceLevel:0
+					sourceOrigin:MTLOriginMake(sourceOffset.x, sourceOffset.y, 0)
+					  sourceSize:MTLSizeMake(sourceExtent.x, sourceExtent.y, 1)
+						toBuffer:polyCast<MetalBuffer>(&destination)->getBuffer()
+			   destinationOffset:destinationOffset
+		  destinationBytesPerRow:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x //Always assume the bytes per row is the same as the image's width. Metal does not consider 0 tightly packed like Vulkan does
+		destinationBytesPerImage:getBytesPerPixel(imageDescriptor.format) * imageDescriptor.dimensions.x * imageDescriptor.dimensions.y * sourceLayerCount];
 	}
-
+	
 	void MetalTransferCommandBuffer::bufferMemoryBarrier(GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
-		//MTLBlitCommandEncoder does not have a barrier. This might not be an issue as a barrier will need to happen on the other queues for owner transfership
+		//MTLBlitCommandEncoder does not have a barrier. This might not be an issue as a barrier will need to happen on the other queues for owner transfer
 		//or will be synchronised with a semaphore / fence
 	}
 	
 	void MetalTransferCommandBuffer::imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
-		//MTLBlitCommandEncoder does not have a barrier. This might not be an issue as a barrier will need to happen on the other queues for owner transfership
+		//MTLBlitCommandEncoder does not have a barrier. This might not be an issue as a barrier will need to happen on the other queues for owner transfer
 		//or will be synchronised with a semaphore / fence
 	}
 }

--- a/clove/components/core/graphics/source/Validation/ValidationCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Validation/ValidationCommandBuffer.cpp
@@ -3,10 +3,6 @@
 #include <Clove/Log/Log.hpp>
 
 namespace clove {
-    void ValidationCommandBuffer::setAllowBufferReuse(bool canReuse) {
-        allowReuse = canReuse;
-    }
-
     void ValidationCommandBuffer::markAsUsed() {
         hasBeenUsed = true;
     }
@@ -15,23 +11,15 @@ namespace clove {
         return hasBeenUsed;
     }
 
-    CommandBufferUsage ValidationCommandBuffer::getCommandBufferUsage() const {
-        return currentUsage;
-    }
-
     void ValidationCommandBuffer::validateBeginRecording() {
         CLOVE_ASSERT_MSG(endRecordingCalled, "beginRecording called before endRecording. Command buffer recording must be finished be starting again.");
         endRecordingCalled = false;
 
-        CLOVE_ASSERT_MSG(!(!allowReuse && hasBeenUsed), "Command buffer re-recorded to. Command buffers cannot be recorded to more than once unless the owning queue has been created with QueueFlags::ReuseBuffers set.");
+        CLOVE_ASSERT_MSG(!hasBeenUsed, "Command buffer re-recorded to. Command buffers cannot be recorded to more than once unless the owning queue has been created with QueueFlags::ReuseBuffers set.");
     }
 
     void ValidationCommandBuffer::resetUsedFlag() {
         hasBeenUsed = false;
-    }
-
-    void ValidationCommandBuffer::setCommandBufferUsage(CommandBufferUsage usage) {
-        currentUsage = usage;
     }
 
     void ValidationCommandBuffer::onEndRecording() {

--- a/clove/components/core/graphics/source/Vulkan/VulkanCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanCommandBuffer.cpp
@@ -9,18 +9,6 @@
 #include <Clove/Log/Log.hpp>
 
 namespace clove {
-    VkCommandBufferUsageFlags getCommandBufferUsageFlags(CommandBufferUsage garlicUsage) {
-        switch(garlicUsage) {
-            case clove::CommandBufferUsage::Default:
-                return 0;
-            case clove::CommandBufferUsage::OneTimeSubmit:
-                return VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-            default:
-                CLOVE_ASSERT_MSG(false, "{0}: Unkown usage type", CLOVE_FUNCTION_NAME);
-                return 0;
-        }
-    }
-
     void createBufferMemoryBarrier(VkCommandBuffer vkCommandBuffer, QueueFamilyIndices const &queueFamilyIndices, GhaBuffer &buffer, BufferMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
         uint32_t const sourceFamilyIndex{ getQueueFamilyIndex(barrierInfo.sourceQueue, queueFamilyIndices) };
         uint32_t const destinationFamilyIndex{ getQueueFamilyIndex(barrierInfo.destinationQueue, queueFamilyIndices) };

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
@@ -68,8 +68,4 @@ namespace clove {
     void VulkanComputeCommandBuffer::imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
         createImageMemoryBarrier(commandBuffer, queueFamilyIndices, image, barrierInfo, sourceStage, destinationStage);
     }
-
-    VkCommandBuffer VulkanComputeCommandBuffer::getCommandBuffer() const {
-        return commandBuffer;
-    }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanComputeCommandBuffer.cpp
@@ -21,10 +21,10 @@ namespace clove {
 
     VulkanComputeCommandBuffer::~VulkanComputeCommandBuffer() = default;
 
-    void VulkanComputeCommandBuffer::beginRecording(CommandBufferUsage usageFlag) {
+    void VulkanComputeCommandBuffer::beginRecording() {
         VkCommandBufferBeginInfo beginInfo{
             .sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-            .flags            = getCommandBufferUsageFlags(usageFlag),
+            .flags            = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
             .pInheritanceInfo = nullptr,
         };
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
@@ -41,10 +41,10 @@ namespace clove {
 
     VulkanGraphicsCommandBuffer::~VulkanGraphicsCommandBuffer() = default;
 
-    void VulkanGraphicsCommandBuffer::beginRecording(CommandBufferUsage usageFlag) {
+    void VulkanGraphicsCommandBuffer::beginRecording() {
         VkCommandBufferBeginInfo beginInfo{
             .sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-            .flags            = getCommandBufferUsageFlags(usageFlag),
+            .flags            = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
             .pInheritanceInfo = nullptr,
         };
 

--- a/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanGraphicsCommandBuffer.cpp
@@ -149,8 +149,4 @@ namespace clove {
     void VulkanGraphicsCommandBuffer::imageMemoryBarrier(GhaImage &image, ImageMemoryBarrierInfo const &barrierInfo, PipelineStage sourceStage, PipelineStage destinationStage) {
         createImageMemoryBarrier(commandBuffer, queueFamilyIndices, image, barrierInfo, sourceStage, destinationStage);
     }
-
-    VkCommandBuffer VulkanGraphicsCommandBuffer::getCommandBuffer() const {
-        return commandBuffer;
-    }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
@@ -103,8 +103,4 @@ namespace clove {
 
         createImageMemoryBarrier(commandBuffer, queueFamilyIndices, image, barrierInfo, sourceStage, destinationStage);
     }
-
-    VkCommandBuffer VulkanTransferCommandBuffer::getCommandBuffer() const {
-        return commandBuffer;
-    }
 }

--- a/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
+++ b/clove/components/core/graphics/source/Vulkan/VulkanTransferCommandBuffer.cpp
@@ -21,10 +21,10 @@ namespace clove {
 
     VulkanTransferCommandBuffer::~VulkanTransferCommandBuffer() = default;
 
-    void VulkanTransferCommandBuffer::beginRecording(CommandBufferUsage usageFlag) {
+    void VulkanTransferCommandBuffer::beginRecording() {
         VkCommandBufferBeginInfo beginInfo{
             .sType            = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-            .flags            = getCommandBufferUsageFlags(usageFlag),
+            .flags            = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
             .pInheritanceInfo = nullptr,
         };
 

--- a/clove/source/Rendering/RenderGraph/RenderGraph.cpp
+++ b/clove/source/Rendering/RenderGraph/RenderGraph.cpp
@@ -404,7 +404,7 @@ namespace clove {
             if(renderPasses.contains(passId)) {
                 GhaGraphicsCommandBuffer *graphicsCommandBufffer{ frameCache.allocateGraphicsCommandBuffer() };
 
-                graphicsCommandBufffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+                graphicsCommandBufffer->beginRecording();
                 executeGraphicsPass(executionPasses, static_cast<int32_t>(passIndex), *graphicsCommandBufffer, allocatedRenderPasses, allocatedFramebuffers, allocatedGraphicsPipelines, allocatedSamplers, allocatedDescriptorSets);
                 graphicsCommandBufffer->endRecording();
 
@@ -421,7 +421,7 @@ namespace clove {
             if(computePasses.contains(passId)) {
                 GhaComputeCommandBuffer *computeCommandBufffer{ frameCache.allocateComputeCommandBuffer() };
 
-                computeCommandBufffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+                computeCommandBufffer->beginRecording();
                 executeComputePass(executionPasses, static_cast<int32_t>(passIndex), *computeCommandBufffer, allocatedComputePipelines, allocatedDescriptorSets);
                 computeCommandBufffer->endRecording();
 
@@ -439,7 +439,7 @@ namespace clove {
             if(asyncComputePasses.contains(passId)) {
                 GhaComputeCommandBuffer *computeCommandBufffer{ frameCache.allocateAsyncComputeCommandBuffer() };
 
-                computeCommandBufffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+                computeCommandBufffer->beginRecording();
                 executeComputePass(executionPasses, static_cast<int32_t>(passIndex), *computeCommandBufffer, allocatedComputePipelines, allocatedDescriptorSets);
                 computeCommandBufffer->endRecording();
 

--- a/clove/source/Rendering/Renderables/Mesh.cpp
+++ b/clove/source/Rendering/Renderables/Mesh.cpp
@@ -13,7 +13,7 @@ namespace clove {
             auto transferQueue{ factory.createTransferQueue({ QueueFlags::Transient }).getValue() };
             auto transferCommandBuffer{ transferQueue->allocateCommandBuffer() };
 
-            transferCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+            transferCommandBuffer->beginRecording();
             transferCommandBuffer->copyBufferToBuffer(source, 0, dest, 0, size);
             transferCommandBuffer->endRecording();
 
@@ -63,7 +63,7 @@ namespace clove {
         stagingBuffer->write(this->indices.data(), indexOffset, indexBufferSize);
 
         //Transfer the data to video memory
-        transferCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+        transferCommandBuffer->beginRecording();
         transferCommandBuffer->copyBufferToBuffer(*stagingBuffer, 0, *combinedBuffer, 0, totalSize);
         transferCommandBuffer->endRecording();
 

--- a/clove/source/Rendering/RenderingHelpers.cpp
+++ b/clove/source/Rendering/RenderingHelpers.cpp
@@ -259,14 +259,14 @@ namespace clove {
         transferBuffer->write(data, bufferOffset, dataSize);
 
         //Change the layout of the image, write the buffer into it and then release the queue ownership
-        transferCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+        transferCommandBuffer->beginRecording();
         transferCommandBuffer->imageMemoryBarrier(*image, layoutTransferInfo, PipelineStage::Top, PipelineStage::Transfer);
         transferCommandBuffer->copyBufferToImage(*transferBuffer, bufferOffset, *image, imageOffset, imageExtent, 0, imageDescriptor.arrayCount);
         transferCommandBuffer->imageMemoryBarrier(*image, transferQueueReleaseInfo, PipelineStage::Transfer, PipelineStage::Transfer);
         transferCommandBuffer->endRecording();
 
         //Acquire ownership of the image to a graphics queue
-        graphicsCommandBuffer->beginRecording(CommandBufferUsage::OneTimeSubmit);
+        graphicsCommandBuffer->beginRecording();
         graphicsCommandBuffer->imageMemoryBarrier(*image, graphicsQueueAcquireInfo, PipelineStage::Transfer, PipelineStage::PixelShader);
         graphicsCommandBuffer->endRecording();
 


### PR DESCRIPTION
## Summary
Remove the ability to replay command buffers. This feature is only natively supported by Vulkan and is fairly niche anyway, especially when rendering games. Removing this removes complexity from the abstraction and will also likely save memory with Metal as now we don't store all those lambdas.

## Changes
- Removed the ability to replay command buffers from the GHA
- inlined `getCommandBuffer`