### PR TITLE
Added `CLOVE_VERIFY` assertion macro

### DIFF
--- a/clove/components/utilities/log/include/Clove/Log/Log.hpp
+++ b/clove/components/utilities/log/include/Clove/Log/Log.hpp
@@ -58,6 +58,11 @@ namespace clove {
 #if CLOVE_ENABLE_ASSERTIONS
 CLOVE_DECLARE_LOG_CATEGORY(CloveAssert)
 
+    /**
+     * @brief Will cause the application to break if the condition is false.
+     * @details This macro can be compiled out if CLOVE_ENABLE_ASSERTIONS is 0. When this happens
+     * any code inside the macro will also be removed. To do an assertion with a side effect see CLOVE_VERIFY.
+     */
     #define CLOVE_ASSERT(x)                                                                                                  \
         {                                                                                                                    \
             if(!(x)) {                                                                                                       \
@@ -67,6 +72,9 @@ CLOVE_DECLARE_LOG_CATEGORY(CloveAssert)
             }                                                                                                                \
         }
 
+    /**
+     * @copydoc CLOVE_ASSERT
+     */
     #define CLOVE_ASSERT_MSG(x, ...)                                                                    \
         {                                                                                               \
             if(!(x)) {                                                                                  \
@@ -75,9 +83,35 @@ CLOVE_DECLARE_LOG_CATEGORY(CloveAssert)
                 CLOVE_DEBUG_BREAK;                                                                      \
             }                                                                                           \
         }
+
+    /**
+     * @brief Will cause the application to break if the condition is false.
+     * @details This macro can be compiled out if CLOVE_ENABLE_ASSERTIONS is 0. However, code inside the macro
+     * will still be executed if this is the case. To compile out the code as well see CLOVE_ASSERT
+     */
+    #define CLOVE_VERIFY(x) CLOVE_ASSERT(x)
+
+    /**
+     * @copydoc CLOVE_VERIFY
+     */
+    #define CLOVE_VERIFY_MSG(x, ...) CLOVE_ASSERT_MSG(x)
 #else
-    #define CLOVE_ASSERT(x) x
-    #define CLOVE_ASSERT_MSG(x, ...) x
+    /**
+     * @copydoc CLOVE_ASSERT
+     */
+    #define CLOVE_ASSERT(x)
+    /**
+     * @copydoc CLOVE_ASSERT
+     */
+    #define CLOVE_ASSERT_MSG(x, ...)
+    /**
+     * @copydoc CLOVE_VERIFY
+     */
+    #define CLOVE_VERIFY(x) x
+    /**
+     * @copydoc CLOVE_VERIFY
+     */
+    #define CLOVE_VERIFY_MSG(x, ...) x
 #endif
 
 #include "Log.inl"

--- a/clove/source/Rendering/Renderables/Font.cpp
+++ b/clove/source/Rendering/Renderables/Font.cpp
@@ -26,7 +26,7 @@ namespace clove {
         }
 
         Font::FacePtr copyFace(FT_Face face) {
-            CLOVE_ASSERT(FT_Reference_Face(face) == FT_Err_Ok);
+            CLOVE_VERIFY(FT_Reference_Face(face) == FT_Err_Ok);
             return makeUniqueFace(face);
         }
     }
@@ -38,7 +38,7 @@ namespace clove {
         , face{ nullptr, nullptr } {
         if(ftLib.use_count() == 0) {
             FT_Library library{ nullptr };
-            CLOVE_ASSERT(FT_Init_FreeType(&library) == FT_Err_Ok);
+            CLOVE_VERIFY(FT_Init_FreeType(&library) == FT_Err_Ok);
 
             CLOVE_LOG(FreeType, LogLevel::Debug, "Constructed FreeType library");
 
@@ -124,7 +124,7 @@ namespace clove {
 
     Font::FacePtr Font::createFace(std::string const &filePath) {
         FT_Face face{ nullptr };
-        CLOVE_ASSERT(FT_New_Face(ftLibReference.get(), filePath.c_str(), 0, &face) == FT_Err_Ok);
+        CLOVE_VERIFY(FT_New_Face(ftLibReference.get(), filePath.c_str(), 0, &face) == FT_Err_Ok);
 
         return makeUniqueFace(face);
     }
@@ -132,7 +132,7 @@ namespace clove {
     Font::FacePtr Font::createFace(std::span<std::byte const> bytes) {
         FT_Face face{ nullptr };
         auto const *ftBytes{ reinterpret_cast<unsigned char const *>(bytes.data()) };
-        CLOVE_ASSERT(FT_New_Memory_Face(ftLibReference.get(), ftBytes, static_cast<FT_Long>(bytes.size_bytes()), 0, &face) == FT_Err_Ok);
+        CLOVE_VERIFY(FT_New_Memory_Face(ftLibReference.get(), ftBytes, static_cast<FT_Long>(bytes.size_bytes()), 0, &face) == FT_Err_Ok);
 
         return makeUniqueFace(face);
     }


### PR DESCRIPTION
## Summary
This macro is to allow for assertions with side effects to still happen when compiled out.

## Changes
- Added `CLOVE_VERIFY` assertion macro