### PR TITLE
Refactored Bulb/Membrane to take *.clvproj through the command line

### DIFF
--- a/bulb/components/membrane/include/Membrane/Application.hpp
+++ b/bulb/components/membrane/include/Membrane/Application.hpp
@@ -21,11 +21,16 @@ public ref class Application {
 
         bool isInEditorMode{ true };
 
+        System::String ^projectFile{};
+        System::String ^gameName{}; /**< The name of the game module's cmake target */
+        System::String ^gameSourceDir{};
+        System::String ^gameContentDir{};
+
         HINSTANCE gameLibrary{ nullptr };
 
         //FUNCTIONS
     public:
-        Application();
+        Application(System::String ^projectFile);
         ~Application();
         !Application();
 
@@ -46,6 +51,6 @@ public ref class Application {
         void setEditorMode(Editor_Stop ^message);
         void setRuntimeMode(Editor_Play ^message);
 
-        bool tryLoadGameDll(std::string_view path);
+        bool tryLoadGameDll(std::filesystem::path const &path);
     };
 }

--- a/bulb/source/EditorApp.xaml.cs
+++ b/bulb/source/EditorApp.xaml.cs
@@ -28,8 +28,13 @@ namespace Bulb {
         }
 
         private void EditorStartup(object sender, StartupEventArgs e) {
+            if(e.Args.Length != 1) {
+                Membrane.Log.write(Membrane.LogLevel.Critical, "Editor requires path to project file passed by command line");
+                throw new ArgumentException($"e.Args needs to have exactly 1 argument. Currently it has {e.Args.Length}");
+            }
+
             //Initialise the engine
-            engineApp = new Membrane.Application();
+            engineApp = new Membrane.Application(e.Args[0]);
 
             sessionViewModel = new EditorSessionViewModel(".");
             sessionViewModel.OnCompileGame = () => {


### PR DESCRIPTION
## Summary
This is a much better solution that just defining a bunch of macros through cmake. Current implementation is still a bit hacky but it'll get there.

## Changes
- Refactored Bulb/Membrane to take *.clvproj through the command line.