### PR TITLE
Various editor usability updates and fixes

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -92,7 +92,7 @@ jobs:
         run: mkdir build
       - name: Prime conan packages
         working-directory: ${{ github.workspace }}/build
-        run: conan install .. --build=missing -s build_type=$BUILD_TYPE -s compiler='clang' -s compiler.version=10 -e CC=clang-10 -e CXX=clang++-10
+        run: conan install .. --build=missing -s build_type=$BUILD_TYPE -s compiler='clang' -s compiler.version=10 -s compiler.libcxx=libstdc++11 -e CC=clang-10 -e CXX=clang++-10
       - name: Configure CMake
         working-directory: ${{ github.workspace }}/build
         run: cmake $CMAKE_FLAGS -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -G "Unix Makefiles" ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         run: mkdir build
       - name: Prime conan packages
         working-directory: ${{ github.workspace }}/build
-        run: conan install .. --build=missing -s build_type=$BUILD_TYPE -s compiler='clang' -s compiler.version=10 -e CC=clang-10 -e CXX=clang++-10
+        run: conan install .. --build=missing -s build_type=$BUILD_TYPE -s compiler='clang' -s compiler.version=10 -s compiler.libcxx=libstdc++11 -e CC=clang-10 -e CXX=clang++-10
       - name: Configure CMake
         working-directory: ${{ github.workspace }}/build
         run: cmake $CMAKE_FLAGS -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -G "Unix Makefiles" ..

--- a/bulb/components/membrane/include/Membrane/Application.hpp
+++ b/bulb/components/membrane/include/Membrane/Application.hpp
@@ -21,10 +21,10 @@ public ref class Application {
 
         bool isInEditorMode{ true };
 
-        System::String ^projectFile{};
-        System::String ^gameName{}; /**< The name of the game module's cmake target */
-        System::String ^gameSourceDir{};
-        System::String ^gameContentDir{};
+        static System::String ^projectFile{};
+        static System::String ^ gameName {}; /**< The name of the game module's cmake target */
+        static System::String ^ gameSourceDir {};
+        static System::String ^ gameContentDir {};
 
         HINSTANCE gameLibrary{ nullptr };
 
@@ -41,7 +41,7 @@ public ref class Application {
         void tick();
         void shutdown();
 
-        System::String ^resolveVfsPath(System::String ^path);
+        static System::String ^getContentPath();
 
         static System::String ^getProjectVersion();
 

--- a/bulb/components/membrane/include/Membrane/FileSystemHelpers.hpp
+++ b/bulb/components/membrane/include/Membrane/FileSystemHelpers.hpp
@@ -10,7 +10,6 @@ namespace membrane {
     public ref class FileSystemHelpers{
         //FUNCTIONS
     public:
-        static System::String ^getContentPath();
         static System::String ^getAssetExtension();
 
         /**

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -29,8 +29,9 @@ typedef void (*LinkReflectionFn)(clove::reflection::internal::Registry *reg);
 using namespace clove;
 
 namespace membrane {
-    Application::Application(System::String ^projectFile) 
-        : projectFile{ projectFile } {
+    Application::Application(System::String ^projectFile) {
+        this->projectFile = projectFile;
+
         std::filesystem::path const projectFilePath{ msclr::interop::marshal_as<std::string>(projectFile) };
 
         if(!std::filesystem::exists(projectFilePath)) {
@@ -143,13 +144,11 @@ namespace membrane {
         fileStream << emittYaml(projectNode);
     }
 
-    System::String ^ Application::resolveVfsPath(System::String ^ path) {
-        System::String ^ managedPath { path };
-        std::string unManagedPath{ msclr::interop::marshal_as<std::string>(managedPath) };
-        return gcnew System::String(app->getFileSystem()->resolve(unManagedPath).c_str());
+    System::String ^Application::getContentPath() {
+        return gameContentDir;
     }
 
-    System::String ^ Application::getProjectVersion() {
+    System::String ^Application::getProjectVersion() {
         return gcnew System::String{ CLOVE_VERSION };
     }
 

--- a/bulb/components/membrane/source/Application.cpp
+++ b/bulb/components/membrane/source/Application.cpp
@@ -84,18 +84,11 @@ namespace membrane {
 
         std::filesystem::remove(dllPath);
 
-        CLOVE_LOG(Membrane, clove::LogLevel::Debug, "Configuring and compiling {0}", nativeName);
+        CLOVE_LOG(Membrane, clove::LogLevel::Debug, "Compiling {0}", nativeName);
 
         {
-            std::stringstream configureStream{};
-            configureStream << "cmake -G \"Visual Studio 16 2019\" " << ROOT_DIR;
-            std::system(configureStream.str().c_str());
-        }
-
-        {
-            //NOTE: The build path here is a bit of a hack as we know on windows we are in the bin/<CONFIG> dir
             std::stringstream buildStream{};
-            buildStream << "cmake --build ../.." << " --target " << nativeName << " --config Debug";
+            buildStream << "cmake --build " << ROOT_DIR"/build" << " --target " << nativeName << " --config Debug";
             std::system(buildStream.str().c_str());
         }
 

--- a/bulb/components/membrane/source/EditorSubSystem.cpp
+++ b/bulb/components/membrane/source/EditorSubSystem.cpp
@@ -241,8 +241,8 @@ namespace membrane {
         rot.y = clove::asRadians(mouseLookYaw);
 
         auto &camTrans{ entityManager->getComponent<clove::TransformComponent>(editorCamera) };
-        camTrans.rotation = rot;
-        camTrans.position += camTrans.rotation * pos * 10.0f * deltaTime.getDeltaSeconds();
+        camTrans.rotation = vec3f{ clove::asDegrees(rot) };
+        camTrans.position += quatf{ rot } * pos * 10.0f * deltaTime.getDeltaSeconds();
     }
 
     void EditorSubSystem::onDetach() {

--- a/bulb/components/membrane/source/FileSystemHelpers.cpp
+++ b/bulb/components/membrane/source/FileSystemHelpers.cpp
@@ -1,6 +1,7 @@
 #include "Membrane/FileSystemHelpers.hpp"
 
 #include "Membrane/MembraneLog.hpp"
+#include "Membrane/Application.hpp"
 
 #include <Clove/Application.hpp>
 #include <Clove/FileSystem/AssetManager.hpp>
@@ -11,10 +12,6 @@
 #include <msclr/marshal_cppstd.h>
 #include <Clove/Application.hpp>
 #include <Clove/FileSystem/AssetManager.hpp>
-
-#ifndef GAME_DIR
-    #define GAME_DIR
-#endif
 
 namespace {
     int32_t convertFileTypeToInt(membrane::FileType type) {
@@ -55,10 +52,6 @@ namespace {
 }
 
 namespace membrane {
-    System::String ^ FileSystemHelpers::getContentPath() {
-        return gcnew System::String{ GAME_DIR "/content" };
-    }
-
     System::String ^ FileSystemHelpers::getAssetExtension() {
         return gcnew System::String{ ".clvasset" };
     }
@@ -125,6 +118,8 @@ namespace membrane {
     }
 
     void FileSystemHelpers::moveAssetFile(System::String ^sourceFileName, System::String ^destFileName) {
+        std::string const contentDir{ msclr::interop::marshal_as<std::string>(membrane::Application::getContentPath()) };
+
         std::filesystem::path const source{ msclr::interop::marshal_as<std::string>(sourceFileName) };
         std::filesystem::path const dest{ msclr::interop::marshal_as<std::string>(destFileName) };
 
@@ -140,8 +135,8 @@ namespace membrane {
         }
 
         //Convert these into the proper vfs paths (folder/model.obj etc.) as the editor will always deal with absolute paths.
-        clove::VirtualFileSystem::Path const sourceVfs{ std::filesystem::relative(source, GAME_DIR "/content").replace_extension(assetPath.extension()) };
-        clove::VirtualFileSystem::Path const destVfs{ std::filesystem::relative(dest, GAME_DIR "/content").replace_extension(assetPath.extension()) };
+        clove::VirtualFileSystem::Path const sourceVfs{ std::filesystem::relative(source, contentDir).replace_extension(assetPath.extension()) };
+        clove::VirtualFileSystem::Path const destVfs{ std::filesystem::relative(dest, contentDir).replace_extension(assetPath.extension()) };
 
         //Notify the asset manager of the move
         switch(getFileType(destFileName)) {

--- a/bulb/components/membrane/source/ReflectionHelpers.cpp
+++ b/bulb/components/membrane/source/ReflectionHelpers.cpp
@@ -176,6 +176,10 @@ namespace membrane {
 
     void deserialiseComponent(reflection::TypeInfo const *const componentTypeInfo, uint8_t *const componentMemory, serialiser::Node const &componentNode, size_t currentOffset) {
         for(auto const &member : componentTypeInfo->members) {
+            if(!componentNode.has(member.name)) {
+                continue;
+            }
+
             size_t const totalMemberOffset{ currentOffset + member.offset };
 
             if(reflection::TypeInfo const *memberType{ reflection::getTypeInfo(member.id) }) {

--- a/bulb/components/membrane/source/RuntimeSubSystem.cpp
+++ b/bulb/components/membrane/source/RuntimeSubSystem.cpp
@@ -28,7 +28,8 @@ namespace membrane {
 
     void RuntimeSubSystem::onAttach() {
         auto loadResult{ loadYaml(clove::Application::get().getFileSystem()->resolve("./scene.clvscene")) };
-        serialiser::Node rootNode{ loadResult.getValue() };
+        serialiser::Node fileNode{ std::move(loadResult.getValue()) };
+        serialiser::Node &rootNode{ fileNode["scene"] };
 
         //Load sub systems
         for(auto const &subSystemNode : rootNode["subSystems"]) {

--- a/bulb/source/EditorApp.xaml.cs
+++ b/bulb/source/EditorApp.xaml.cs
@@ -22,7 +22,7 @@ namespace Bulb {
             engineApp.loadGameDll();
             engineApp.startSession();
 
-            sessionViewModel.Start(Membrane.FileSystemHelpers.getContentPath()); //TEMP: Remove with multiple window support
+            sessionViewModel.Start(Membrane.Application.getContentPath()); //TEMP: Remove with multiple window support
 
             return href;
         }
@@ -53,8 +53,6 @@ namespace Bulb {
 
             CompositionTarget.Rendering += RunEngineApplication;
         }
-
-        public string ResolveVfsPath(string path) => engineApp.resolveVfsPath(path);
 
         private void ShutdownEngine(object sender, EventArgs e) => engineApp.shutdown();
 

--- a/bulb/source/ViewModels/EditorSessionViewModel.cs
+++ b/bulb/source/ViewModels/EditorSessionViewModel.cs
@@ -7,6 +7,11 @@ namespace Bulb {
     /// The View Model for the entire editor's session. Used to manage the viewmodels that make up the editor itself.
     /// </summary>
     public class EditorSessionViewModel : ViewModel {
+        private enum PlayMode {
+            Playing,
+            Stopped,
+        }
+
         public ICommand LoadSceneCommand { get; }
         public ICommand SaveSceneCommand { get; }
         public ICommand PlayCommand { get; }
@@ -53,6 +58,8 @@ namespace Bulb {
         }
         private bool isStopButtonEnabled = false;
 
+        private PlayMode playMode;
+
         public delegate void CompileDelegate();
         public CompileDelegate OnCompileGame;
 
@@ -76,23 +83,36 @@ namespace Bulb {
             //FileExplorer = new FileExplorerViewModel(rootFilePath);
 
             WindowTitle = $"Clove - {Membrane.Application.getProjectVersion()}";
+
+            //Assuming we are initialised as stopped
+            playMode = PlayMode.Stopped;
         }
 
         //TEMP: Just to make sure functions don't get called before opening a window.
         public void Start(string rootFilePath) => FileExplorer = new FileExplorerViewModel(rootFilePath);
 
-        private void OnSceneLoaded(Membrane.Engine_OnSceneLoaded message) => Scene = new SceneViewModel(message.enabledSubSystems, message.entities);
+        public void Play() {
+            if(playMode == PlayMode.Playing) {
+                return;
+            }
+            playMode = PlayMode.Playing;
 
-        private void Play() {
             IsPlayButtonEnabled = false;
             IsStopButtonEnabled = true;
             Membrane.MessageHandler.sendMessage(new Membrane.Editor_Play());
         }
 
-        private void Stop() {
+        public void Stop() {
+            if(playMode == PlayMode.Stopped) {
+                return;
+            }
+            playMode = PlayMode.Stopped;
+
             IsPlayButtonEnabled = true;
             IsStopButtonEnabled = false;
             Membrane.MessageHandler.sendMessage(new Membrane.Editor_Stop());
         }
+
+        private void OnSceneLoaded(Membrane.Engine_OnSceneLoaded message) => Scene = new SceneViewModel(message.enabledSubSystems, message.entities);
     }
 }

--- a/bulb/source/Views/MainWindow.xaml
+++ b/bulb/source/Views/MainWindow.xaml
@@ -4,9 +4,9 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Bulb"
-		xmlns:membrane="clr-namespace:membrane;assembly=BulbMembrane"
         mc:Ignorable="d"
-        Title="{Binding WindowTitle}" Width="1280" Height="720">
+        Title="{Binding WindowTitle}" Width="1280" Height="720"
+        KeyDown="Window_KeyDown">
 	<Grid>
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition/>

--- a/bulb/source/Views/MainWindow.xaml.cs
+++ b/bulb/source/Views/MainWindow.xaml.cs
@@ -8,6 +8,8 @@ namespace Bulb {
     /// Interaction logic for MainWindow.xaml
     /// </summary>
     public partial class MainWindow : Window {
+        private EditorSessionViewModel ViewModel => DataContext as EditorSessionViewModel;
+
         public MainWindow() {
             InitializeComponent();
 
@@ -55,6 +57,12 @@ namespace Bulb {
             textBox.Visibility = Visibility.Collapsed;
             textBox.LostFocus -= EditTextBoxLostFocus;
             e.Handled = true;
+        }
+
+        private void Window_KeyDown(object sender, KeyEventArgs e) {
+            if(e.Key == Key.Escape) {
+                ViewModel.Stop();
+            }
         }
     }
 }

--- a/clove/components/systems/serialisation/include/Clove/Serialisation/Node.hpp
+++ b/clove/components/systems/serialisation/include/Clove/Serialisation/Node.hpp
@@ -59,6 +59,7 @@ namespace clove::serialiser {
         inline Type getType() const;
         inline std::string getKey() const;
         inline size_t numChildren() const;
+        inline bool has(std::string_view nodeName) const;
 
         inline VectorType::iterator begin();
         inline VectorType::iterator end();

--- a/clove/components/systems/serialisation/include/Clove/Serialisation/Node.inl
+++ b/clove/components/systems/serialisation/include/Clove/Serialisation/Node.inl
@@ -57,6 +57,16 @@ namespace clove::serialiser {
         return nodes.size();
     }
 
+    bool Node::has(std::string_view nodeName) const {
+        for(auto const &node : nodes) {
+            if(node.scalar == nodeName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     Node::VectorType::iterator Node::begin() {
         return nodes.begin();
     }

--- a/clove/components/systems/serialisation/tests/NodeTests.cpp
+++ b/clove/components/systems/serialisation/tests/NodeTests.cpp
@@ -39,6 +39,14 @@ TEST(NodeTests, CanAddNamedChildOntoNode) {
     EXPECT_EQ(node.numChildren(), 1);
 }
 
+TEST(NodeTests, CanCheckIfANodeHasAChild) {
+    Node node{};
+    node["child"] = 3;
+
+    EXPECT_TRUE(node.has("child"));
+    EXPECT_FALSE(node.has("other"));
+}
+
 TEST(NodeTests, CanAddPushBackChildOntoNode) {
     Node node{};
 

--- a/clove/include/Clove/Components/TransformComponent.hpp
+++ b/clove/include/Clove/Components/TransformComponent.hpp
@@ -8,9 +8,9 @@ namespace clove {
      * @brief A TransformComponent holds the position, rotation and scale of an Entity.
      */
     struct TransformComponent {
-        vec3f position{ 0.0f, 0.0f, 0.0f };          /**< The local position of this transform. */
-        quatf rotation{ vec3f{ 0.0f, 0.0f, 0.0f } }; /**< The local rotation of this transform. */
-        vec3f scale{ 1.0f, 1.0f, 1.0f };             /**< The local scale of this transform. */
+        vec3f position{ 0.0f, 0.0f, 0.0f }; /**< The local position of this transform. */
+        vec3f rotation{ 0.0f, 0.0f, 0.0f }; /**< The local rotation of this transform. Note: This is done in degrees for editor usability. */
+        vec3f scale{ 1.0f, 1.0f, 1.0f };    /**< The local scale of this transform. */
 
         /**
          * @brief Contains the world matrix which this transforms local matrix multiplied 

--- a/clove/source/SubSystems/PhysicsSubSystem.cpp
+++ b/clove/source/SubSystems/PhysicsSubSystem.cpp
@@ -14,6 +14,7 @@
 #include <Clove/Event/EventDispatcher.hpp>
 #include <Clove/ReflectionAttributes.hpp>
 #include <btBulletDynamicsCommon.h>
+#include <Clove/Maths/MathsHelpers.hpp>
 
 namespace clove {
     namespace {
@@ -114,7 +115,8 @@ namespace clove {
             if(!entityManager->hasComponent<CollisionShapeComponent>(entity) || !entityManager->hasComponent<RigidBodyComponent>(entity)) {
                 proxiesToRemove.push_back(entity);
             }
-        }, Exclude<ShapeOnlyComponent, BodyOnlyComponent>{});
+        },
+                               Exclude<ShapeOnlyComponent, BodyOnlyComponent>{});
 
         //Remove them outside of the loops their found in.
         for(auto entity : proxiesToRemove) {
@@ -203,7 +205,7 @@ namespace clove {
         //Notify Bullet of the location of the colliders
         entityManager->forEach([&](TransformComponent const &transform, PhysicsProxyComponent const &proxy) {
             auto const &pos{ transform.position };
-            auto const &rot{ transform.rotation };
+            quatf const rot{ asRadians(transform.rotation) };
             auto const &scale{ transform.scale };
 
             btTransform btTrans{ proxy.collisionObject->getWorldTransform() };
@@ -226,7 +228,7 @@ namespace clove {
             btQuaternion const &rot{ btTrans.getRotation() };
 
             transform.position = vec3f{ pos.x(), pos.y(), pos.z() };
-            transform.rotation = quatf{ rot.getW(), rot.getX(), rot.getY(), rot.getZ() };
+            transform.rotation = asDegrees(quaternionToEuler(quatf{ rot.getW(), rot.getX(), rot.getY(), rot.getZ() }));
         });
         entityManager->forEach([](RigidBodyComponent &body, PhysicsProxyComponent const &proxy) {
             auto *btBody{ static_cast<btRigidBody *>(proxy.collisionObject.get()) };//NOLINT

--- a/clove/source/SubSystems/TransformSubSystem.cpp
+++ b/clove/source/SubSystems/TransformSubSystem.cpp
@@ -13,9 +13,9 @@ namespace clove {
         mat4f calculateWorldMatrix(EntityManager *entityManager, TransformComponent &transform, Entity parent) {
             if(entityManager->hasComponent<TransformComponent>(parent)) {
                 auto &parentTransform{ entityManager->getComponent<TransformComponent>(parent) };
-                
+
                 Entity parentsParent{ NullEntity };
-                if(entityManager->hasComponent<ParentComponent>(parent)){
+                if(entityManager->hasComponent<ParentComponent>(parent)) {
                     parentsParent = entityManager->getComponent<ParentComponent>(parent).parent;
                 }
 
@@ -46,8 +46,10 @@ namespace clove {
 
         //Calculate the world matrix of every single transform
         entityManager->forEach([](TransformComponent &transform) {
+            vec3f const radRot{ asRadians(transform.rotation) };
+
             mat4f const translationMatrix{ translate(mat4f{ 1.0f }, transform.position) };
-            mat4f const rotationMatrix{ quaternionToMatrix4(transform.rotation) };
+            mat4f const rotationMatrix{ quaternionToMatrix4(quatf{ radRot }) };
             mat4f const scaleMatrix{ scale(mat4f{ 1.0f }, transform.scale) };
 
             transform.worldMatrix = translationMatrix * rotationMatrix * scaleMatrix;


### PR DESCRIPTION
## Changes
- Modified `TransformComponent::rotation` to be a euler angles in degrees.
- Used cached `gameContentDir` instead of old macro.
- No longer configure the game project when compiling.
- Fixed an issue where `RuntimeSubSystem` would deserialise from the wrong node.
- Fixed a crash that could occur when a sub system attaches other sub systems.
- Fixed a crash that could occur when adding a new member onto a serialised component.
- Users can now press ESC to leave play mode.